### PR TITLE
feat: add reward cut change notification for delegators

### DIFF
--- a/apollo/subgraph.ts
+++ b/apollo/subgraph.ts
@@ -10923,3 +10923,65 @@ export function useVoteLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<VoteQ
 export type VoteQueryHookResult = ReturnType<typeof useVoteQuery>;
 export type VoteLazyQueryHookResult = ReturnType<typeof useVoteLazyQuery>;
 export type VoteQueryResult = Apollo.QueryResult<VoteQuery, VoteQueryVariables>;
+export type DelegateRewardCutQueryVariables = Exact<{
+  id: Scalars['ID'];
+  delegate: Scalars['String'];
+  timestamp_gte: Scalars['Int'];
+}>;
+
+
+export type DelegateRewardCutQuery = { __typename: 'Query', delegator?: { __typename: 'Delegator', id: string, delegate?: { __typename: 'Transcoder', id: string, rewardCut: string, rewardCutUpdateTimestamp: number } | null } | null, transcoderUpdateEvents: Array<{ __typename: 'TranscoderUpdateEvent', id: string, rewardCut: string, feeShare: string, timestamp: number }> };
+
+export const DelegateRewardCutDocument = gql`
+    query delegateRewardCut($id: ID!, $delegate: String!, $timestamp_gte: Int!) {
+  delegator(id: $id) {
+    id
+    delegate {
+      id
+      rewardCut
+      rewardCutUpdateTimestamp
+    }
+  }
+  transcoderUpdateEvents(
+    where: {delegate: $delegate, timestamp_gte: $timestamp_gte}
+    orderBy: timestamp
+    orderDirection: desc
+    first: 5
+  ) {
+    id
+    rewardCut
+    feeShare
+    timestamp
+  }
+}
+    `;
+
+/**
+ * __useDelegateRewardCutQuery__
+ *
+ * To run a query within a React component, call `useDelegateRewardCutQuery` and pass it any options that fit your needs.
+ * When your component renders, `useDelegateRewardCutQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useDelegateRewardCutQuery({
+ *   variables: {
+ *      id: // value for 'id'
+ *      delegate: // value for 'delegate'
+ *      timestamp_gte: // value for 'timestamp_gte'
+ *   },
+ * });
+ */
+export function useDelegateRewardCutQuery(baseOptions: Apollo.QueryHookOptions<DelegateRewardCutQuery, DelegateRewardCutQueryVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useQuery<DelegateRewardCutQuery, DelegateRewardCutQueryVariables>(DelegateRewardCutDocument, options);
+      }
+export function useDelegateRewardCutLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<DelegateRewardCutQuery, DelegateRewardCutQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useLazyQuery<DelegateRewardCutQuery, DelegateRewardCutQueryVariables>(DelegateRewardCutDocument, options);
+        }
+export type DelegateRewardCutQueryHookResult = ReturnType<typeof useDelegateRewardCutQuery>;
+export type DelegateRewardCutLazyQueryHookResult = ReturnType<typeof useDelegateRewardCutLazyQuery>;
+export type DelegateRewardCutQueryResult = Apollo.QueryResult<DelegateRewardCutQuery, DelegateRewardCutQueryVariables>;

--- a/components/RewardCutNotification/index.tsx
+++ b/components/RewardCutNotification/index.tsx
@@ -1,0 +1,175 @@
+import { LAYOUT_MAX_WIDTH } from "@layouts/constants";
+import dayjs from "@lib/dayjs";
+import { formatAddress } from "@lib/utils";
+import { Box, Button, Container, Text } from "@livepeer/design-system";
+import { useDelegateRewardCutQuery } from "apollo";
+import { useAccountAddress, useEnsData } from "hooks";
+import Link from "next/link";
+import numbro from "numbro";
+import { useEffect, useMemo, useState } from "react";
+
+const NOTIFICATION_WINDOW_SECONDS = 7 * 24 * 60 * 60; // 7 days
+
+const RewardCutNotification = () => {
+  const accountAddress = useAccountAddress();
+
+  const [timestampThreshold, setTimestampThreshold] = useState(0);
+
+  useEffect(() => {
+    setTimestampThreshold(
+      Math.floor(Date.now() / 1000) - NOTIFICATION_WINDOW_SECONDS
+    );
+  }, []);
+
+  const { data, loading } = useDelegateRewardCutQuery({
+    variables: {
+      id: accountAddress?.toLowerCase() ?? "",
+      delegate: accountAddress?.toLowerCase() ?? "",
+      timestamp_gte: timestampThreshold,
+    },
+    pollInterval: 120000,
+    skip: !accountAddress || timestampThreshold === 0,
+  });
+
+  const delegateId = data?.delegator?.delegate?.id;
+  const delegateIdentity = useEnsData(delegateId);
+
+  // Refetch with actual delegate ID once we know it
+  const { data: delegateData } = useDelegateRewardCutQuery({
+    variables: {
+      id: accountAddress?.toLowerCase() ?? "",
+      delegate: delegateId?.toLowerCase() ?? "",
+      timestamp_gte: timestampThreshold,
+    },
+    pollInterval: 120000,
+    skip: !accountAddress || !delegateId || timestampThreshold === 0,
+  });
+
+  const rewardCutInfo = useMemo(() => {
+    if (!delegateData?.delegator?.delegate) return null;
+
+    const delegate = delegateData.delegator.delegate;
+    const updateTimestamp = delegate.rewardCutUpdateTimestamp;
+
+    // Check if the reward cut was updated within the notification window
+    if (updateTimestamp < timestampThreshold) return null;
+
+    const events = delegateData.transcoderUpdateEvents;
+    const currentRewardCut = Number(delegate.rewardCut) / 1000000;
+
+    // Find the previous reward cut from events (the second most recent, or the oldest in our window)
+    let previousRewardCut: number | null = null;
+    if (events.length >= 2) {
+      previousRewardCut = Number(events[events.length - 1].rewardCut) / 1000000;
+    }
+
+    return {
+      currentRewardCut,
+      previousRewardCut,
+      updateTimestamp,
+      delegateId: delegate.id,
+      increased:
+        previousRewardCut !== null
+          ? currentRewardCut > previousRewardCut
+          : null,
+    };
+  }, [delegateData, timestampThreshold]);
+
+  // Don't show if the user is their own delegate (orchestrator)
+  const isOrchestrator = data?.delegator?.delegate?.id === data?.delegator?.id;
+
+  if (loading || !rewardCutInfo || isOrchestrator) {
+    return null;
+  }
+
+  const delegateName =
+    delegateIdentity?.name || formatAddress(rewardCutInfo.delegateId);
+
+  return (
+    <Container css={{ maxWidth: LAYOUT_MAX_WIDTH, marginBottom: "$5" }}>
+      <Box
+        css={{
+          marginTop: "$5",
+          borderRadius: 10,
+          width: "100%",
+          padding: "$4",
+          color: "$loContrast",
+          backgroundColor:
+            rewardCutInfo.increased === false ? "$blue11" : "$amber11",
+        }}
+      >
+        <Box
+          css={{
+            marginBottom: "$2",
+            fontSize: "$6",
+            fontWeight: 600,
+          }}
+        >
+          Reward Cut{" "}
+          {rewardCutInfo.increased === true
+            ? "Increased"
+            : rewardCutInfo.increased === false
+            ? "Decreased"
+            : "Updated"}
+        </Box>
+        <Box>
+          <Text css={{ color: "$loContrast" }}>
+            Your orchestrator{" "}
+            <Text as="span" css={{ fontWeight: 600, color: "$loContrast" }}>
+              {delegateName}
+            </Text>{" "}
+            {rewardCutInfo.previousRewardCut !== null ? (
+              <>
+                changed their reward cut from{" "}
+                <Text as="span" css={{ fontWeight: 600, color: "$loContrast" }}>
+                  {numbro(rewardCutInfo.previousRewardCut).format({
+                    output: "percent",
+                    mantissa: 2,
+                  })}
+                </Text>{" "}
+                to{" "}
+                <Text as="span" css={{ fontWeight: 600, color: "$loContrast" }}>
+                  {numbro(rewardCutInfo.currentRewardCut).format({
+                    output: "percent",
+                    mantissa: 2,
+                  })}
+                </Text>
+              </>
+            ) : (
+              <>
+                updated their reward cut to{" "}
+                <Text as="span" css={{ fontWeight: 600, color: "$loContrast" }}>
+                  {numbro(rewardCutInfo.currentRewardCut).format({
+                    output: "percent",
+                    mantissa: 2,
+                  })}
+                </Text>
+              </>
+            )}{" "}
+            {dayjs.unix(rewardCutInfo.updateTimestamp).fromNow()}.
+            {rewardCutInfo.increased && (
+              <>
+                {" "}
+                This means you will receive a smaller share of inflationary
+                rewards.
+              </>
+            )}
+          </Text>
+          <Link href="/orchestrators" passHref>
+            <Button
+              as="a"
+              size="3"
+              css={{ marginTop: "$2" }}
+              variant="transparentBlack"
+              ghost
+            >
+              View Orchestrators
+            </Button>
+          </Link>
+        </Box>
+      </Box>
+    </Container>
+  );
+};
+
+export default RewardCutNotification;

--- a/layouts/main.tsx
+++ b/layouts/main.tsx
@@ -5,6 +5,7 @@ import InactiveWarning from "@components/InactiveWarning";
 import Logo from "@components/Logo";
 import PopoverLink from "@components/PopoverLink";
 import ProgressBar from "@components/ProgressBar";
+import RewardCutNotification from "@components/RewardCutNotification";
 import Search from "@components/Search";
 import TxStartedDialog from "@components/TxStartedDialog";
 import TxSummaryDialog from "@components/TxSummaryDialog";
@@ -706,6 +707,9 @@ const Layout = ({ children, title = "Livepeer Explorer" }) => {
                   <Box css={{ width: "100%" }}>
                     {!asPath.includes("/migrate") && accountAddress && (
                       <InactiveWarning />
+                    )}
+                    {!asPath.includes("/migrate") && accountAddress && (
+                      <RewardCutNotification />
                     )}
                     {!asPath?.includes("/migrate") && accountAddress && (
                       <Claim />

--- a/queries/delegateRewardCut.graphql
+++ b/queries/delegateRewardCut.graphql
@@ -1,0 +1,21 @@
+query delegateRewardCut($id: ID!, $delegate: String!, $timestamp_gte: Int!) {
+  delegator(id: $id) {
+    id
+    delegate {
+      id
+      rewardCut
+      rewardCutUpdateTimestamp
+    }
+  }
+  transcoderUpdateEvents(
+    where: { delegate: $delegate, timestamp_gte: $timestamp_gte }
+    orderBy: timestamp
+    orderDirection: desc
+    first: 5
+  ) {
+    id
+    rewardCut
+    feeShare
+    timestamp
+  }
+}


### PR DESCRIPTION
Show a banner notification when a delegator's orchestrator has changed
their reward cut within the last 7 days. The notification displays the
previous and current reward cut percentages, highlights whether it
increased or decreased, and links to the orchestrators page.

https://claude.ai/code/session_01AteSaeJgqwkwTEJqH5XxMc