### PR TITLE
fix: cache supply change data per round to prevent fluctuations on reload

### DIFF
--- a/hooks/useSwr.tsx
+++ b/hooks/useSwr.tsx
@@ -69,9 +69,25 @@ export const useChangefeedData = () => {
   return data ?? null;
 };
 
+export const useCurrentRoundData = () => {
+  const { data } = useSWR<CurrentRoundInfo>(`/current-round`, {
+    refreshInterval: 10000,
+  });
+
+  return data ?? null;
+};
+
 export const useSupplyChangeData = () => {
-  const { data, error, isValidating } =
-    useSWR<SupplyChangeData>(`/supply-change`);
+  const currentRound = useCurrentRoundData();
+
+  // Key on current round ID so we only refetch when a new round starts
+  const { data, error, isValidating } = useSWR<SupplyChangeData>(
+    currentRound?.id ? `/supply-change?round=${currentRound.id}` : null,
+    {
+      revalidateOnFocus: false,
+      revalidateOnReconnect: false,
+    }
+  );
 
   return {
     data: data ?? null,
@@ -105,14 +121,6 @@ export const useScoreData = (address: string | undefined | null) => {
   const { data } = useSWR<PerformanceMetrics>(
     address ? `/score/${address.toLowerCase()}` : null
   );
-
-  return data ?? null;
-};
-
-export const useCurrentRoundData = () => {
-  const { data } = useSWR<CurrentRoundInfo>(`/current-round`, {
-    refreshInterval: 10000,
-  });
 
   return data ?? null;
 };


### PR DESCRIPTION
The supply data was refetching on every page load/focus because SWR
revalidated eagerly. Since the subgraph's Day entity totalSupply updates
on every orchestrator reward() call (many times per round), each reload
showed slightly different values.

Fix by keying the SWR cache on the current round ID so supply change
data is only fetched once per round, and disabling revalidateOnFocus
and revalidateOnReconnect.

https://claude.ai/code/session_011cbt1CFvT4hrZh5zp9MVxL