### PR TITLE
feat: add reward & fee cut history chart to orchestrator page

### DIFF
--- a/apollo/subgraph.ts
+++ b/apollo/subgraph.ts
@@ -10843,6 +10843,50 @@ export function useTranscoderActivatedEventsLazyQuery(baseOptions?: Apollo.LazyQ
 export type TranscoderActivatedEventsQueryHookResult = ReturnType<typeof useTranscoderActivatedEventsQuery>;
 export type TranscoderActivatedEventsLazyQueryHookResult = ReturnType<typeof useTranscoderActivatedEventsLazyQuery>;
 export type TranscoderActivatedEventsQueryResult = Apollo.QueryResult<TranscoderActivatedEventsQuery, TranscoderActivatedEventsQueryVariables>;
+
+export type TranscoderUpdateEventsQueryVariables = Exact<{
+  where?: InputMaybe<TranscoderUpdateEvent_Filter>;
+  first?: InputMaybe<Scalars['Int']>;
+  orderBy?: InputMaybe<TranscoderUpdateEvent_OrderBy>;
+  orderDirection?: InputMaybe<OrderDirection>;
+}>;
+
+export type TranscoderUpdateEventsQuery = { __typename: 'Query', transcoderUpdateEvents: Array<{ __typename: 'TranscoderUpdateEvent', id: string, rewardCut: string, feeShare: string, timestamp: number, round: { __typename: 'Round', id: string }, transaction: { __typename: 'Transaction', id: string } }> };
+
+export const TranscoderUpdateEventsDocument = gql`
+    query transcoderUpdateEvents($where: TranscoderUpdateEvent_filter, $first: Int, $orderBy: TranscoderUpdateEvent_orderBy, $orderDirection: OrderDirection) {
+  transcoderUpdateEvents(
+    where: $where
+    first: $first
+    orderBy: $orderBy
+    orderDirection: $orderDirection
+  ) {
+    id
+    rewardCut
+    feeShare
+    timestamp
+    round {
+      id
+    }
+    transaction {
+      id
+    }
+  }
+}
+    `;
+
+export function useTranscoderUpdateEventsQuery(baseOptions?: Apollo.QueryHookOptions<TranscoderUpdateEventsQuery, TranscoderUpdateEventsQueryVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useQuery<TranscoderUpdateEventsQuery, TranscoderUpdateEventsQueryVariables>(TranscoderUpdateEventsDocument, options);
+      }
+export function useTranscoderUpdateEventsLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<TranscoderUpdateEventsQuery, TranscoderUpdateEventsQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useLazyQuery<TranscoderUpdateEventsQuery, TranscoderUpdateEventsQueryVariables>(TranscoderUpdateEventsDocument, options);
+        }
+export type TranscoderUpdateEventsQueryHookResult = ReturnType<typeof useTranscoderUpdateEventsQuery>;
+export type TranscoderUpdateEventsLazyQueryHookResult = ReturnType<typeof useTranscoderUpdateEventsLazyQuery>;
+export type TranscoderUpdateEventsQueryResult = Apollo.QueryResult<TranscoderUpdateEventsQuery, TranscoderUpdateEventsQueryVariables>;
+
 export const TreasuryProposalDocument = gql`
     query treasuryProposal($id: ID!) {
   treasuryProposal(id: $id) {

--- a/components/OrchestratingView/index.tsx
+++ b/components/OrchestratingView/index.tsx
@@ -1,3 +1,4 @@
+import RewardCutHistory from "@components/RewardCutHistory";
 import Stat from "@components/Stat";
 import dayjs from "@lib/dayjs";
 import { Box, Flex, Link as A, Text } from "@livepeer/design-system";
@@ -435,6 +436,7 @@ const Index = ({ currentRound, transcoder, isActive }: Props) => {
           />
         </A>
       </Masonry>
+      <RewardCutHistory transcoderId={transcoder?.id} />
     </Box>
   );
 };

--- a/components/OrchestratingView/index.tsx
+++ b/components/OrchestratingView/index.tsx
@@ -165,6 +165,7 @@ const Index = ({ currentRound, transcoder, isActive }: Props) => {
         },
       }}
     >
+      <RewardCutHistory transcoderId={transcoder?.id} />
       <Masonry
         breakpointCols={breakpointColumnsObj}
         className="masonry-grid"
@@ -436,7 +437,6 @@ const Index = ({ currentRound, transcoder, isActive }: Props) => {
           />
         </A>
       </Masonry>
-      <RewardCutHistory transcoderId={transcoder?.id} />
     </Box>
   );
 };

--- a/components/RewardCutHistory/index.tsx
+++ b/components/RewardCutHistory/index.tsx
@@ -289,7 +289,7 @@ const RewardCutHistory = ({ transcoderId }: Props) => {
                   </Flex>
                 </ExplorerTooltip>
                 <Flex>
-                  {(chartData?.length || 0) <= 0 ? (
+                  {loading || (chartData?.length || 0) <= 0 ? (
                     <Skeleton
                       css={{ marginTop: "$1", width: "100%", height: 20 }}
                     />
@@ -349,10 +349,10 @@ const RewardCutHistory = ({ transcoderId }: Props) => {
 
               {/* Chart area - matches ExplorerChart's paddingTop: 57 */}
               <Box css={{ paddingTop: 57, width: "100%", height: "100%" }}>
-                <ResponsiveContainer width="100%" height="100%">
-                  {(chartData?.length || 0) <= 0 ? (
-                    <Skeleton css={{ width: "100%", height: "100%" }} />
-                  ) : (
+                {loading || (chartData?.length || 0) <= 0 ? (
+                  <Skeleton css={{ width: "100%", height: "100%" }} />
+                ) : (
+                  <ResponsiveContainer width="100%" height="100%">
                     <LineChart
                       data={chartData}
                       onMouseMove={(e) => {
@@ -410,8 +410,8 @@ const RewardCutHistory = ({ transcoderId }: Props) => {
                         strokeWidth={2}
                       />
                     </LineChart>
-                  )}
-                </ResponsiveContainer>
+                  </ResponsiveContainer>
+                )}
               </Box>
             </Box>
           </Panel>

--- a/components/RewardCutHistory/index.tsx
+++ b/components/RewardCutHistory/index.tsx
@@ -76,13 +76,16 @@ export const Panel = ({ children }) => (
       minHeight: 240,
       height: 240,
       padding: "24px",
+      paddingRight: "32px",
       flexDirection: "column",
       alignItems: "center",
       justifyContent: "center",
       border: "0.5px solid $colors$neutral4",
       flex: 1,
       width: "100%",
-      minWidth: 350,
+      "@bp1": {
+        minWidth: 350,
+      },
     }}
   >
     {children}
@@ -170,7 +173,7 @@ const RewardCutHistory = ({ transcoderId }: Props) => {
           backgroundColor: "$panel",
           borderRadius: "$4",
           border: "1px solid $colors$neutral4",
-          overflow: "hidden",
+          overflow: "visible",
           marginBottom: "$4",
         }}
       >

--- a/components/RewardCutHistory/index.tsx
+++ b/components/RewardCutHistory/index.tsx
@@ -10,18 +10,18 @@ import {
   TranscoderUpdateEvent_OrderBy,
   useTranscoderUpdateEventsQuery,
 } from "apollo";
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import {
   Line,
   LineChart,
   ResponsiveContainer,
-  Tooltip,
+  Tooltip as ReTooltip,
   XAxis,
   YAxis,
 } from "recharts";
 
-const MALICIOUS_THRESHOLD = 50; // swing of 50+ percentage points is suspicious
-const MIN_CHANGES_FOR_WARNING = 2; // need at least 2 changes to detect a pattern
+const MALICIOUS_THRESHOLD = 50;
+const MIN_CHANGES_FOR_WARNING = 2;
 
 type ChartDatum = {
   timestamp: number;
@@ -29,89 +29,61 @@ type ChartDatum = {
   feeCut: number;
 };
 
-const CustomTooltip = ({
+// Matches ExplorerChart's hidden tooltip pattern to avoid console errors
+const CustomContentOfTooltip = ({
   active,
   payload,
 }: {
   active?: boolean;
-  payload?: Array<{ payload: ChartDatum }>;
+  payload?: unknown[];
 }) => {
-  if (!active || !payload?.length) return null;
-  const data = payload[0].payload;
+  const isVisible = active && payload && payload.length;
   return (
-    <Box
-      css={{
-        backgroundColor: "$neutral3",
-        border: "1px solid $neutral6",
-        borderRadius: "$2",
-        padding: "$2",
-      }}
-    >
-      <Text css={{ fontSize: "$1", color: "$neutral11", marginBottom: "$1" }}>
-        {dayjs.unix(data.timestamp).format("MMM D, YYYY")}
-      </Text>
-      <Flex css={{ alignItems: "center", gap: "$1" }}>
-        <Box
-          css={{
-            width: 8,
-            height: 8,
-            borderRadius: "50%",
-            backgroundColor: "#ff6b6b",
-          }}
-        />
-        <Text css={{ fontSize: "$2", color: "$hiContrast" }}>
-          Reward Cut: {data.rewardCut.toFixed(1)}%
-        </Text>
-      </Flex>
-      <Flex css={{ alignItems: "center", gap: "$1" }}>
-        <Box
-          css={{
-            width: 8,
-            height: 8,
-            borderRadius: "50%",
-            backgroundColor: "#4ecdc4",
-          }}
-        />
-        <Text css={{ fontSize: "$2", color: "$hiContrast" }}>
-          Fee Cut: {data.feeCut.toFixed(1)}%
-        </Text>
-      </Flex>
-    </Box>
+    <div
+      className="custom-tooltip"
+      style={{ visibility: isVisible ? "visible" : "hidden" }}
+    />
   );
 };
 
-const CustomXAxisTick = ({ x, y, payload }) => (
-  <g transform={`translate(${x},${y})`}>
-    <text
-      x={0}
-      y={0}
-      dy={14}
-      textAnchor="end"
-      fill="white"
-      fontWeight={400}
-      fontSize="12px"
-    >
-      {dayjs.unix(payload.value).format("MMM YY")}
-    </text>
-  </g>
-);
+// Matches ExplorerChart's CustomizedXAxisTick exactly
+const CustomizedXAxisTick = ({ x, y, payload }) => {
+  return (
+    <g transform={`translate(${x},${y})`}>
+      <text
+        x={0}
+        y={0}
+        dy={14}
+        textAnchor="end"
+        fill="white"
+        fontWeight={400}
+        fontSize="13px"
+      >
+        {dayjs.unix(payload.value).format("MMM YY")}
+      </text>
+    </g>
+  );
+};
 
-const CustomYAxisTick = ({ x, y, payload }) => (
-  <g transform={`translate(${x},${y})`}>
-    <text
-      x={0}
-      y={0}
-      dx={1}
-      dy={0}
-      textAnchor="start"
-      fill="white"
-      fontWeight={400}
-      fontSize="12px"
-    >
-      {payload.value}%
-    </text>
-  </g>
-);
+// Matches ExplorerChart's CustomizedYAxisTick style
+const CustomizedYAxisTick = ({ x, y, payload }) => {
+  return (
+    <g transform={`translate(${x},${y})`}>
+      <text
+        x={0}
+        y={0}
+        dx={1}
+        dy={0}
+        textAnchor="start"
+        fill="white"
+        fontWeight={400}
+        fontSize="13px"
+      >
+        {payload.value}%
+      </text>
+    </g>
+  );
+};
 
 export const Panel = ({ children }) => (
   <Flex
@@ -153,8 +125,8 @@ const RewardCutHistory = ({ transcoderId }: Props) => {
     if (!data?.transcoderUpdateEvents?.length) return [];
     const events = data.transcoderUpdateEvents.map((event) => ({
       timestamp: event.timestamp,
-      rewardCut: (Number(event.rewardCut) / 1000000) * 100, // 1000000 = 100%
-      feeCut: (1 - Number(event.feeShare) / 1000000) * 100, // feeShare is inverse of feeCut
+      rewardCut: (Number(event.rewardCut) / 1000000) * 100,
+      feeCut: (1 - Number(event.feeShare) / 1000000) * 100,
     }));
 
     // Add a "now" anchor point with the most recent values so the chart
@@ -201,20 +173,33 @@ const RewardCutHistory = ({ transcoderId }: Props) => {
     return null;
   }, [chartData]);
 
-  const [hovered, setHovered] = useState<{
-    rewardCut: string;
-    feeCut: string;
-    date: string | null;
-  } | null>(null);
-
-  const currentValues = useMemo(() => {
-    if (!chartData.length) return { rewardCut: "N/A", feeCut: "N/A" };
+  const defaultValues = useMemo(() => {
+    if (!chartData.length)
+      return { rewardCut: "N/A", feeCut: "N/A" };
     const last = chartData[chartData.length - 1];
     return {
       rewardCut: `${last.rewardCut.toFixed(1)}%`,
       feeCut: `${last.feeCut.toFixed(1)}%`,
     };
   }, [chartData]);
+
+  const [selected, setSelected] = useState<{
+    rewardCut: string;
+    feeCut: string;
+    date: string | null;
+  }>({
+    rewardCut: defaultValues.rewardCut,
+    feeCut: defaultValues.feeCut,
+    date: null,
+  });
+
+  useEffect(() => {
+    setSelected((prev) => ({
+      ...prev,
+      rewardCut: defaultValues.rewardCut,
+      feeCut: defaultValues.feeCut,
+    }));
+  }, [defaultValues]);
 
   if (!transcoderId) return null;
 
@@ -249,7 +234,7 @@ const RewardCutHistory = ({ transcoderId }: Props) => {
         </Flex>
       )}
 
-      {/* Chart grid - matches homepage Panel pattern */}
+      {/* Chart grid - matches homepage layout */}
       <Flex
         css={{
           backgroundColor: "$panel",
@@ -270,6 +255,7 @@ const RewardCutHistory = ({ transcoderId }: Props) => {
           }}
         >
           <Panel>
+            {/* Matches ExplorerChart's position: relative wrapper */}
             <Box
               css={{
                 position: "relative",
@@ -277,7 +263,7 @@ const RewardCutHistory = ({ transcoderId }: Props) => {
                 height: "100%",
               }}
             >
-              {/* Header overlay */}
+              {/* Header overlay - matches ExplorerChart's absolute header */}
               <Box css={{ position: "absolute", zIndex: 3 }}>
                 <ExplorerTooltip
                   multiline
@@ -302,101 +288,115 @@ const RewardCutHistory = ({ transcoderId }: Props) => {
                     </Box>
                   </Flex>
                 </ExplorerTooltip>
-                <Flex css={{ gap: "$3", marginTop: "$1" }}>
-                  <Flex css={{ alignItems: "center", gap: "$1" }}>
-                    <Box
-                      css={{
-                        width: 8,
-                        height: 8,
-                        borderRadius: "50%",
-                        backgroundColor: "#ff6b6b",
-                      }}
+                <Flex>
+                  {(chartData?.length || 0) <= 0 ? (
+                    <Skeleton
+                      css={{ marginTop: "$1", width: "100%", height: 20 }}
                     />
-                    <Text
-                      css={{
-                        fontWeight: 600,
-                        fontSize: "$3",
-                        color: "white",
-                      }}
-                    >
-                      {hovered ? hovered.rewardCut : currentValues.rewardCut}
-                    </Text>
-                  </Flex>
-                  <Flex css={{ alignItems: "center", gap: "$1" }}>
-                    <Box
-                      css={{
-                        width: 8,
-                        height: 8,
-                        borderRadius: "50%",
-                        backgroundColor: "#4ecdc4",
-                      }}
-                    />
-                    <Text
-                      css={{
-                        fontWeight: 600,
-                        fontSize: "$3",
-                        color: "white",
-                      }}
-                    >
-                      {hovered ? hovered.feeCut : currentValues.feeCut}
-                    </Text>
-                  </Flex>
+                  ) : (
+                    <Flex css={{ gap: "$3" }}>
+                      <Flex css={{ alignItems: "center", gap: "$1" }}>
+                        <Box
+                          css={{
+                            width: 8,
+                            height: 8,
+                            borderRadius: "50%",
+                            backgroundColor: "#ff6b6b",
+                          }}
+                        />
+                        <Text
+                          css={{
+                            fontWeight: 600,
+                            fontSize: "$3",
+                            color: "white",
+                          }}
+                        >
+                          {selected.rewardCut}
+                        </Text>
+                      </Flex>
+                      <Flex css={{ alignItems: "center", gap: "$1" }}>
+                        <Box
+                          css={{
+                            width: 8,
+                            height: 8,
+                            borderRadius: "50%",
+                            backgroundColor: "#4ecdc4",
+                          }}
+                        />
+                        <Text
+                          css={{
+                            fontWeight: 600,
+                            fontSize: "$3",
+                            color: "white",
+                          }}
+                        >
+                          {selected.feeCut}
+                        </Text>
+                      </Flex>
+                    </Flex>
+                  )}
                 </Flex>
-                {hovered?.date && (
-                  <Text
-                    css={{
-                      fontWeight: 600,
-                      fontSize: "$2",
-                      color: "white",
-                    }}
-                  >
-                    {hovered.date}
-                  </Text>
-                )}
+                <Text
+                  css={{
+                    fontWeight: 600,
+                    fontSize: "$2",
+                    color: "white",
+                  }}
+                >
+                  {selected.date}
+                </Text>
               </Box>
 
-              {/* Chart area */}
+              {/* Chart area - matches ExplorerChart's paddingTop: 57 */}
               <Box css={{ paddingTop: 57, width: "100%", height: "100%" }}>
-                {loading || chartData.length === 0 ? (
-                  <Skeleton
-                    css={{ width: "100%", height: "100%", borderRadius: 8 }}
-                  />
-                ) : (
-                  <ResponsiveContainer width="100%" height="100%">
+                <ResponsiveContainer width="100%" height="100%">
+                  {(chartData?.length || 0) <= 0 ? (
+                    <Skeleton css={{ width: "100%", height: "100%" }} />
+                  ) : (
                     <LineChart
                       data={chartData}
                       onMouseMove={(e) => {
                         if (e?.activePayload?.[0]) {
                           const d = e.activePayload[0].payload as ChartDatum;
-                          setHovered({
+                          setSelected({
                             rewardCut: `${d.rewardCut.toFixed(1)}%`,
                             feeCut: `${d.feeCut.toFixed(1)}%`,
-                            date: dayjs
-                              .unix(d.timestamp)
-                              .format("MMM D, YYYY"),
+                            date: dayjs.unix(d.timestamp).format("MMM D"),
+                          });
+                        } else {
+                          setSelected({
+                            rewardCut: defaultValues.rewardCut,
+                            feeCut: defaultValues.feeCut,
+                            date: null,
                           });
                         }
                       }}
-                      onMouseLeave={() => setHovered(null)}
+                      onMouseLeave={() =>
+                        setSelected({
+                          rewardCut: defaultValues.rewardCut,
+                          feeCut: defaultValues.feeCut,
+                          date: null,
+                        })
+                      }
                     >
                       <XAxis
                         dataKey="timestamp"
-                        tick={CustomXAxisTick}
+                        tick={CustomizedXAxisTick}
                         interval="preserveStartEnd"
                       />
                       <YAxis
                         width={35}
                         orientation="right"
-                        tick={CustomYAxisTick}
+                        tick={CustomizedYAxisTick}
                         domain={[0, 100]}
                       />
-                      <Tooltip content={<CustomTooltip />} />
+                      <ReTooltip content={CustomContentOfTooltip} />
                       <Line
                         dataKey="rewardCut"
                         name="Reward Cut"
                         type="stepAfter"
-                        dot={{ r: 2, strokeWidth: 0, fill: "#ff6b6b" }}
-                        activeDot={{ r: 4, strokeWidth: 0 }}
+                        dot={{ r: 0, strokeWidth: 0 }}
+                        activeDot={{ r: 3, strokeWidth: 0 }}
                         stroke="#ff6b6b"
                         strokeWidth={2}
                       />
@@ -404,14 +404,14 @@ const RewardCutHistory = ({ transcoderId }: Props) => {
                         dataKey="feeCut"
                         name="Fee Cut"
                         type="stepAfter"
-                        dot={{ r: 2, strokeWidth: 0, fill: "#4ecdc4" }}
-                        activeDot={{ r: 4, strokeWidth: 0 }}
+                        dot={{ r: 0, strokeWidth: 0 }}
+                        activeDot={{ r: 3, strokeWidth: 0 }}
                         stroke="#4ecdc4"
                         strokeWidth={2}
                       />
                     </LineChart>
-                  </ResponsiveContainer>
-                )}
+                  )}
+                </ResponsiveContainer>
               </Box>
             </Box>
           </Panel>

--- a/components/RewardCutHistory/index.tsx
+++ b/components/RewardCutHistory/index.tsx
@@ -1,0 +1,354 @@
+import { ExplorerTooltip } from "@components/ExplorerTooltip";
+import dayjs from "@lib/dayjs";
+import { Box, Card, Flex, Skeleton, Text } from "@livepeer/design-system";
+import {
+  ExclamationTriangleIcon,
+  QuestionMarkCircledIcon,
+} from "@modulz/radix-icons";
+import {
+  OrderDirection,
+  TranscoderUpdateEvent_OrderBy,
+  useTranscoderUpdateEventsQuery,
+} from "apollo";
+import { useMemo, useState } from "react";
+import {
+  Line,
+  LineChart,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from "recharts";
+
+const MALICIOUS_THRESHOLD = 50; // swing of 50+ percentage points is suspicious
+const MIN_CHANGES_FOR_WARNING = 2; // need at least 2 changes to detect a pattern
+
+type ChartDatum = {
+  timestamp: number;
+  rewardCut: number;
+  feeCut: number;
+};
+
+const CustomTooltip = ({
+  active,
+  payload,
+}: {
+  active?: boolean;
+  payload?: Array<{ payload: ChartDatum }>;
+}) => {
+  if (!active || !payload?.length) return null;
+  const data = payload[0].payload;
+  return (
+    <Box
+      css={{
+        backgroundColor: "$neutral3",
+        border: "1px solid $neutral6",
+        borderRadius: "$2",
+        padding: "$2",
+      }}
+    >
+      <Text css={{ fontSize: "$1", color: "$neutral11", marginBottom: "$1" }}>
+        {dayjs.unix(data.timestamp).format("MMM D, YYYY")}
+      </Text>
+      <Flex css={{ alignItems: "center", gap: "$1" }}>
+        <Box
+          css={{
+            width: 8,
+            height: 8,
+            borderRadius: "50%",
+            backgroundColor: "#ff6b6b",
+          }}
+        />
+        <Text css={{ fontSize: "$2", color: "$hiContrast" }}>
+          Reward Cut: {data.rewardCut.toFixed(1)}%
+        </Text>
+      </Flex>
+      <Flex css={{ alignItems: "center", gap: "$1" }}>
+        <Box
+          css={{
+            width: 8,
+            height: 8,
+            borderRadius: "50%",
+            backgroundColor: "#4ecdc4",
+          }}
+        />
+        <Text css={{ fontSize: "$2", color: "$hiContrast" }}>
+          Fee Cut: {data.feeCut.toFixed(1)}%
+        </Text>
+      </Flex>
+    </Box>
+  );
+};
+
+const CustomXAxisTick = ({ x, y, payload }) => (
+  <g transform={`translate(${x},${y})`}>
+    <text
+      x={0}
+      y={0}
+      dy={14}
+      textAnchor="end"
+      fill="white"
+      fontWeight={400}
+      fontSize="12px"
+    >
+      {dayjs.unix(payload.value).format("MMM YY")}
+    </text>
+  </g>
+);
+
+const CustomYAxisTick = ({ x, y, payload }) => (
+  <g transform={`translate(${x},${y})`}>
+    <text
+      x={0}
+      y={0}
+      dx={1}
+      dy={0}
+      textAnchor="start"
+      fill="white"
+      fontWeight={400}
+      fontSize="12px"
+    >
+      {payload.value}%
+    </text>
+  </g>
+);
+
+interface Props {
+  transcoderId?: string;
+}
+
+const RewardCutHistory = ({ transcoderId }: Props) => {
+  const { data, loading } = useTranscoderUpdateEventsQuery({
+    variables: {
+      where: {
+        delegate: transcoderId,
+      },
+      first: 1000,
+      orderBy: TranscoderUpdateEvent_OrderBy.Timestamp,
+      orderDirection: OrderDirection.Asc,
+    },
+    skip: !transcoderId,
+  });
+
+  const chartData = useMemo<ChartDatum[]>(() => {
+    if (!data?.transcoderUpdateEvents) return [];
+    return data.transcoderUpdateEvents.map((event) => ({
+      timestamp: event.timestamp,
+      rewardCut: (Number(event.rewardCut) / 1000000) * 100, // 1000000 = 100%
+      feeCut: (1 - Number(event.feeShare) / 1000000) * 100, // feeShare is inverse of feeCut
+    }));
+  }, [data]);
+
+  const warning = useMemo(() => {
+    if (chartData.length < MIN_CHANGES_FOR_WARNING) return null;
+
+    let maxRewardCutSwing = 0;
+    let maxFeeCutSwing = 0;
+
+    for (let i = 1; i < chartData.length; i++) {
+      const rewardSwing = Math.abs(
+        chartData[i].rewardCut - chartData[i - 1].rewardCut
+      );
+      const feeSwing = Math.abs(
+        chartData[i].feeCut - chartData[i - 1].feeCut
+      );
+      maxRewardCutSwing = Math.max(maxRewardCutSwing, rewardSwing);
+      maxFeeCutSwing = Math.max(maxFeeCutSwing, feeSwing);
+    }
+
+    if (
+      maxRewardCutSwing >= MALICIOUS_THRESHOLD ||
+      maxFeeCutSwing >= MALICIOUS_THRESHOLD
+    ) {
+      return `This orchestrator has changed their ${
+        maxRewardCutSwing >= MALICIOUS_THRESHOLD ? "reward cut" : "fee cut"
+      } by ${Math.max(maxRewardCutSwing, maxFeeCutSwing).toFixed(0)}+ percentage points. Large swings may indicate a bait-and-switch strategy where delegators are attracted with low cuts that are later raised.`;
+    }
+
+    return null;
+  }, [chartData]);
+
+  const [hovered, setHovered] = useState<{
+    rewardCut: string;
+    feeCut: string;
+    date: string | null;
+  } | null>(null);
+
+  const currentValues = useMemo(() => {
+    if (!chartData.length)
+      return { rewardCut: "N/A", feeCut: "N/A" };
+    const last = chartData[chartData.length - 1];
+    return {
+      rewardCut: `${last.rewardCut.toFixed(1)}%`,
+      feeCut: `${last.feeCut.toFixed(1)}%`,
+    };
+  }, [chartData]);
+
+  if (!transcoderId) return null;
+
+  return (
+    <Card
+      variant="active"
+      css={{
+        padding: "$3",
+        boxShadow: "$colors$neutral5 0px 0px 0px 1px inset",
+        marginTop: "$3",
+      }}
+    >
+      {/* Header */}
+      <Flex
+        css={{
+          justifyContent: "space-between",
+          alignItems: "flex-start",
+          marginBottom: "$2",
+        }}
+      >
+        <Box>
+          <Flex css={{ alignItems: "center" }}>
+            <Text
+              css={{
+                fontSize: "$2",
+                color: "$neutral9",
+                textTransform: "uppercase",
+                fontWeight: 600,
+              }}
+            >
+              Reward & Fee Cut History
+            </Text>
+            <ExplorerTooltip
+              multiline
+              content="Historical changes to the orchestrator's reward cut and fee cut over time. Large sudden changes may indicate malicious behavior."
+            >
+              <Flex css={{ marginLeft: "$1" }}>
+                <Box
+                  as={QuestionMarkCircledIcon}
+                  css={{ color: "$neutral11" }}
+                />
+              </Flex>
+            </ExplorerTooltip>
+          </Flex>
+          <Flex css={{ gap: "$3", marginTop: "$1" }}>
+            <Flex css={{ alignItems: "center", gap: "$1" }}>
+              <Box
+                css={{
+                  width: 8,
+                  height: 8,
+                  borderRadius: "50%",
+                  backgroundColor: "#ff6b6b",
+                }}
+              />
+              <Text css={{ fontSize: "$2", color: "$hiContrast", fontWeight: 600 }}>
+                Reward Cut:{" "}
+                {hovered ? hovered.rewardCut : currentValues.rewardCut}
+              </Text>
+            </Flex>
+            <Flex css={{ alignItems: "center", gap: "$1" }}>
+              <Box
+                css={{
+                  width: 8,
+                  height: 8,
+                  borderRadius: "50%",
+                  backgroundColor: "#4ecdc4",
+                }}
+              />
+              <Text css={{ fontSize: "$2", color: "$hiContrast", fontWeight: 600 }}>
+                Fee Cut: {hovered ? hovered.feeCut : currentValues.feeCut}
+              </Text>
+            </Flex>
+          </Flex>
+          {hovered?.date && (
+            <Text css={{ fontSize: "$1", color: "$neutral11", marginTop: "$1" }}>
+              {hovered.date}
+            </Text>
+          )}
+        </Box>
+      </Flex>
+
+      {/* Warning Banner */}
+      {warning && (
+        <Flex
+          css={{
+            backgroundColor: "rgba(255, 107, 107, 0.1)",
+            border: "1px solid rgba(255, 107, 107, 0.3)",
+            borderRadius: "$2",
+            padding: "$2",
+            marginBottom: "$2",
+            alignItems: "flex-start",
+            gap: "$2",
+          }}
+        >
+          <Box
+            as={ExclamationTriangleIcon}
+            css={{
+              color: "#ff6b6b",
+              flexShrink: 0,
+              marginTop: 2,
+              width: 16,
+              height: 16,
+            }}
+          />
+          <Text css={{ fontSize: "$2", color: "#ff6b6b", lineHeight: 1.4 }}>
+            {warning}
+          </Text>
+        </Flex>
+      )}
+
+      {/* Chart */}
+      <Box css={{ width: "100%", height: 200 }}>
+        {loading || chartData.length === 0 ? (
+          <Skeleton css={{ width: "100%", height: "100%", borderRadius: 8 }} />
+        ) : (
+          <ResponsiveContainer width="100%" height="100%">
+            <LineChart
+              data={chartData}
+              onMouseMove={(e) => {
+                if (e?.activePayload?.[0]) {
+                  const d = e.activePayload[0].payload as ChartDatum;
+                  setHovered({
+                    rewardCut: `${d.rewardCut.toFixed(1)}%`,
+                    feeCut: `${d.feeCut.toFixed(1)}%`,
+                    date: dayjs.unix(d.timestamp).format("MMM D, YYYY"),
+                  });
+                }
+              }}
+              onMouseLeave={() => setHovered(null)}
+            >
+              <XAxis
+                dataKey="timestamp"
+                tick={CustomXAxisTick}
+                interval="preserveStartEnd"
+              />
+              <YAxis
+                width={35}
+                orientation="right"
+                tick={CustomYAxisTick}
+                domain={[0, 100]}
+              />
+              <Tooltip content={<CustomTooltip />} />
+              <Line
+                dataKey="rewardCut"
+                name="Reward Cut"
+                type="stepAfter"
+                dot={{ r: 2, strokeWidth: 0, fill: "#ff6b6b" }}
+                activeDot={{ r: 4, strokeWidth: 0 }}
+                stroke="#ff6b6b"
+                strokeWidth={2}
+              />
+              <Line
+                dataKey="feeCut"
+                name="Fee Cut"
+                type="stepAfter"
+                dot={{ r: 2, strokeWidth: 0, fill: "#4ecdc4" }}
+                activeDot={{ r: 4, strokeWidth: 0 }}
+                stroke="#4ecdc4"
+                strokeWidth={2}
+              />
+            </LineChart>
+          </ResponsiveContainer>
+        )}
+      </Box>
+    </Card>
+  );
+};
+
+export default RewardCutHistory;

--- a/components/RewardCutHistory/index.tsx
+++ b/components/RewardCutHistory/index.tsx
@@ -1,10 +1,8 @@
 import { ExplorerTooltip } from "@components/ExplorerTooltip";
 import dayjs from "@lib/dayjs";
 import { Box, Flex, Skeleton, Text } from "@livepeer/design-system";
-import {
-  ExclamationTriangleIcon,
-  QuestionMarkCircledIcon,
-} from "@modulz/radix-icons";
+import { QuestionMarkCircledIcon } from "@modulz/radix-icons";
+import { FiAlertTriangle } from "react-icons/fi";
 import {
   OrderDirection,
   TranscoderUpdateEvent_OrderBy,
@@ -165,9 +163,7 @@ const RewardCutHistory = ({ transcoderId }: Props) => {
       maxRewardCutSwing >= MALICIOUS_THRESHOLD ||
       maxFeeCutSwing >= MALICIOUS_THRESHOLD
     ) {
-      return `This orchestrator has changed their ${
-        maxRewardCutSwing >= MALICIOUS_THRESHOLD ? "reward cut" : "fee cut"
-      } by ${Math.max(maxRewardCutSwing, maxFeeCutSwing).toFixed(0)}+ percentage points. Large swings may indicate a bait-and-switch strategy where delegators are attracted with low cuts that are later raised.`;
+      return "This orchestrator has a history of making large changes to their cut percentages. This may indicate a bait-and-switch strategy. Review the chart below before delegating.";
     }
 
     return null;
@@ -208,27 +204,35 @@ const RewardCutHistory = ({ transcoderId }: Props) => {
       {/* Warning Banner - above the chart grid */}
       {warning && (
         <Flex
+          role="alert"
           css={{
-            backgroundColor: "rgba(255, 107, 107, 0.1)",
-            border: "1px solid rgba(255, 107, 107, 0.3)",
-            borderRadius: "$2",
-            padding: "$2",
+            alignItems: "center",
+            backgroundColor: "$amber3",
+            border: "1px solid $amber6",
+            borderRadius: 10,
+            padding: "$3",
             marginBottom: "$3",
-            alignItems: "flex-start",
             gap: "$2",
           }}
         >
           <Box
-            as={ExclamationTriangleIcon}
+            as={FiAlertTriangle}
+            aria-hidden="true"
             css={{
-              color: "#ff6b6b",
+              color: "$amber11",
               flexShrink: 0,
-              marginTop: 2,
               width: 16,
               height: 16,
             }}
           />
-          <Text css={{ fontSize: "$2", color: "#ff6b6b", lineHeight: 1.4 }}>
+          <Text
+            css={{
+              fontSize: "$2",
+              color: "$amber11",
+              fontWeight: 400,
+              lineHeight: 1.4,
+            }}
+          >
             {warning}
           </Text>
         </Flex>

--- a/components/RewardCutHistory/index.tsx
+++ b/components/RewardCutHistory/index.tsx
@@ -2,13 +2,9 @@ import { ExplorerTooltip } from "@components/ExplorerTooltip";
 import dayjs from "@lib/dayjs";
 import { Box, Flex, Skeleton, Text } from "@livepeer/design-system";
 import { QuestionMarkCircledIcon } from "@modulz/radix-icons";
-import { FiAlertTriangle } from "react-icons/fi";
-import {
-  OrderDirection,
-  TranscoderUpdateEvent_OrderBy,
-  useTranscoderUpdateEventsQuery,
-} from "apollo";
+import { useRewardCutHistory } from "hooks/useRewardCutHistory";
 import { useEffect, useMemo, useState } from "react";
+import { FiAlertTriangle } from "react-icons/fi";
 import {
   Line,
   LineChart,
@@ -17,15 +13,6 @@ import {
   XAxis,
   YAxis,
 } from "recharts";
-
-const MALICIOUS_THRESHOLD = 50;
-const MIN_CHANGES_FOR_WARNING = 2;
-
-type ChartDatum = {
-  timestamp: number;
-  rewardCut: number;
-  feeCut: number;
-};
 
 // Matches ExplorerChart's hidden tooltip pattern to avoid console errors
 const CustomContentOfTooltip = ({
@@ -107,71 +94,10 @@ interface Props {
 }
 
 const RewardCutHistory = ({ transcoderId }: Props) => {
-  const { data, loading } = useTranscoderUpdateEventsQuery({
-    variables: {
-      where: {
-        delegate: transcoderId,
-      },
-      first: 1000,
-      orderBy: TranscoderUpdateEvent_OrderBy.Timestamp,
-      orderDirection: OrderDirection.Asc,
-    },
-    skip: !transcoderId,
-  });
-
-  const chartData = useMemo<ChartDatum[]>(() => {
-    if (!data?.transcoderUpdateEvents?.length) return [];
-    const events = data.transcoderUpdateEvents.map((event) => ({
-      timestamp: event.timestamp,
-      rewardCut: (Number(event.rewardCut) / 1000000) * 100,
-      feeCut: (1 - Number(event.feeShare) / 1000000) * 100,
-    }));
-
-    // Add a "now" anchor point with the most recent values so the chart
-    // extends to the present day instead of ending at the last change
-    const last = events[events.length - 1];
-    const now = Math.floor(Date.now() / 1000);
-    if (now - last.timestamp > 86400) {
-      events.push({
-        timestamp: now,
-        rewardCut: last.rewardCut,
-        feeCut: last.feeCut,
-      });
-    }
-
-    return events;
-  }, [data]);
-
-  const warning = useMemo(() => {
-    if (chartData.length < MIN_CHANGES_FOR_WARNING) return null;
-
-    let maxRewardCutSwing = 0;
-    let maxFeeCutSwing = 0;
-
-    for (let i = 1; i < chartData.length; i++) {
-      const rewardSwing = Math.abs(
-        chartData[i].rewardCut - chartData[i - 1].rewardCut
-      );
-      const feeSwing = Math.abs(
-        chartData[i].feeCut - chartData[i - 1].feeCut
-      );
-      maxRewardCutSwing = Math.max(maxRewardCutSwing, rewardSwing);
-      maxFeeCutSwing = Math.max(maxFeeCutSwing, feeSwing);
-    }
-
-    if (
-      maxRewardCutSwing >= MALICIOUS_THRESHOLD ||
-      maxFeeCutSwing >= MALICIOUS_THRESHOLD
-    ) {
-      return "This orchestrator has a history of making large changes to their cut percentages. This may indicate a bait-and-switch strategy. Review the chart below before delegating.";
-    }
-
-    return null;
-  }, [chartData]);
+  const { chartData, loading, warning } = useRewardCutHistory(transcoderId);
 
   const defaultValues = useMemo(() => {
-    if (!chartData.length)
-      return { rewardCut: "N/A", feeCut: "N/A" };
+    if (!chartData.length) return { rewardCut: "N/A", feeCut: "N/A" };
     const last = chartData[chartData.length - 1];
     return {
       rewardCut: `${last.rewardCut.toFixed(1)}%`,
@@ -233,7 +159,7 @@ const RewardCutHistory = ({ transcoderId }: Props) => {
               lineHeight: 1.4,
             }}
           >
-            {warning}
+            {warning.message}
           </Text>
         </Flex>
       )}
@@ -361,7 +287,11 @@ const RewardCutHistory = ({ transcoderId }: Props) => {
                       data={chartData}
                       onMouseMove={(e) => {
                         if (e?.activePayload?.[0]) {
-                          const d = e.activePayload[0].payload as ChartDatum;
+                          const d = e.activePayload[0].payload as {
+                            timestamp: number;
+                            rewardCut: number;
+                            feeCut: number;
+                          };
                           setSelected({
                             rewardCut: `${d.rewardCut.toFixed(1)}%`,
                             feeCut: `${d.feeCut.toFixed(1)}%`,

--- a/components/RewardCutHistory/index.tsx
+++ b/components/RewardCutHistory/index.tsx
@@ -1,6 +1,6 @@
 import { ExplorerTooltip } from "@components/ExplorerTooltip";
 import dayjs from "@lib/dayjs";
-import { Box, Card, Flex, Skeleton, Text } from "@livepeer/design-system";
+import { Box, Flex, Skeleton, Text } from "@livepeer/design-system";
 import {
   ExclamationTriangleIcon,
   QuestionMarkCircledIcon,
@@ -113,6 +113,25 @@ const CustomYAxisTick = ({ x, y, payload }) => (
   </g>
 );
 
+export const Panel = ({ children }) => (
+  <Flex
+    css={{
+      minHeight: 240,
+      height: 240,
+      padding: "24px",
+      flexDirection: "column",
+      alignItems: "center",
+      justifyContent: "center",
+      border: "0.5px solid $colors$neutral4",
+      flex: 1,
+      width: "100%",
+      minWidth: 350,
+    }}
+  >
+    {children}
+  </Flex>
+);
+
 interface Props {
   transcoderId?: string;
 }
@@ -189,8 +208,7 @@ const RewardCutHistory = ({ transcoderId }: Props) => {
   } | null>(null);
 
   const currentValues = useMemo(() => {
-    if (!chartData.length)
-      return { rewardCut: "N/A", feeCut: "N/A" };
+    if (!chartData.length) return { rewardCut: "N/A", feeCut: "N/A" };
     const last = chartData[chartData.length - 1];
     return {
       rewardCut: `${last.rewardCut.toFixed(1)}%`,
@@ -201,84 +219,8 @@ const RewardCutHistory = ({ transcoderId }: Props) => {
   if (!transcoderId) return null;
 
   return (
-    <Card
-      variant="active"
-      css={{
-        padding: "$3",
-        boxShadow: "$colors$neutral5 0px 0px 0px 1px inset",
-        marginTop: "$3",
-      }}
-    >
-      {/* Header */}
-      <Flex
-        css={{
-          justifyContent: "space-between",
-          alignItems: "flex-start",
-          marginBottom: "$2",
-        }}
-      >
-        <Box>
-          <Flex css={{ alignItems: "center" }}>
-            <Text
-              css={{
-                fontSize: "$2",
-                color: "$neutral9",
-                textTransform: "uppercase",
-                fontWeight: 600,
-              }}
-            >
-              Reward & Fee Cut History
-            </Text>
-            <ExplorerTooltip
-              multiline
-              content="Historical changes to the orchestrator's reward cut and fee cut over time. Large sudden changes may indicate malicious behavior."
-            >
-              <Flex css={{ marginLeft: "$1" }}>
-                <Box
-                  as={QuestionMarkCircledIcon}
-                  css={{ color: "$neutral11" }}
-                />
-              </Flex>
-            </ExplorerTooltip>
-          </Flex>
-          <Flex css={{ gap: "$3", marginTop: "$1" }}>
-            <Flex css={{ alignItems: "center", gap: "$1" }}>
-              <Box
-                css={{
-                  width: 8,
-                  height: 8,
-                  borderRadius: "50%",
-                  backgroundColor: "#ff6b6b",
-                }}
-              />
-              <Text css={{ fontSize: "$2", color: "$hiContrast", fontWeight: 600 }}>
-                Reward Cut:{" "}
-                {hovered ? hovered.rewardCut : currentValues.rewardCut}
-              </Text>
-            </Flex>
-            <Flex css={{ alignItems: "center", gap: "$1" }}>
-              <Box
-                css={{
-                  width: 8,
-                  height: 8,
-                  borderRadius: "50%",
-                  backgroundColor: "#4ecdc4",
-                }}
-              />
-              <Text css={{ fontSize: "$2", color: "$hiContrast", fontWeight: 600 }}>
-                Fee Cut: {hovered ? hovered.feeCut : currentValues.feeCut}
-              </Text>
-            </Flex>
-          </Flex>
-          {hovered?.date && (
-            <Text css={{ fontSize: "$1", color: "$neutral11", marginTop: "$1" }}>
-              {hovered.date}
-            </Text>
-          )}
-        </Box>
-      </Flex>
-
-      {/* Warning Banner */}
+    <Box>
+      {/* Warning Banner - above the chart grid */}
       {warning && (
         <Flex
           css={{
@@ -286,7 +228,7 @@ const RewardCutHistory = ({ transcoderId }: Props) => {
             border: "1px solid rgba(255, 107, 107, 0.3)",
             borderRadius: "$2",
             padding: "$2",
-            marginBottom: "$2",
+            marginBottom: "$3",
             alignItems: "flex-start",
             gap: "$2",
           }}
@@ -307,61 +249,175 @@ const RewardCutHistory = ({ transcoderId }: Props) => {
         </Flex>
       )}
 
-      {/* Chart */}
-      <Box css={{ width: "100%", height: 200 }}>
-        {loading || chartData.length === 0 ? (
-          <Skeleton css={{ width: "100%", height: "100%", borderRadius: 8 }} />
-        ) : (
-          <ResponsiveContainer width="100%" height="100%">
-            <LineChart
-              data={chartData}
-              onMouseMove={(e) => {
-                if (e?.activePayload?.[0]) {
-                  const d = e.activePayload[0].payload as ChartDatum;
-                  setHovered({
-                    rewardCut: `${d.rewardCut.toFixed(1)}%`,
-                    feeCut: `${d.feeCut.toFixed(1)}%`,
-                    date: dayjs.unix(d.timestamp).format("MMM D, YYYY"),
-                  });
-                }
+      {/* Chart grid - matches homepage Panel pattern */}
+      <Flex
+        css={{
+          backgroundColor: "$panel",
+          borderRadius: "$4",
+          border: "1px solid $colors$neutral4",
+          overflow: "hidden",
+          marginBottom: "$4",
+        }}
+      >
+        <Box
+          css={{
+            width: "100%",
+            display: "grid",
+            gridTemplateColumns: "1fr",
+            "@bp2": {
+              gridTemplateColumns: "1fr",
+            },
+          }}
+        >
+          <Panel>
+            <Box
+              css={{
+                position: "relative",
+                width: "100%",
+                height: "100%",
               }}
-              onMouseLeave={() => setHovered(null)}
             >
-              <XAxis
-                dataKey="timestamp"
-                tick={CustomXAxisTick}
-                interval="preserveStartEnd"
-              />
-              <YAxis
-                width={35}
-                orientation="right"
-                tick={CustomYAxisTick}
-                domain={[0, 100]}
-              />
-              <Tooltip content={<CustomTooltip />} />
-              <Line
-                dataKey="rewardCut"
-                name="Reward Cut"
-                type="stepAfter"
-                dot={{ r: 2, strokeWidth: 0, fill: "#ff6b6b" }}
-                activeDot={{ r: 4, strokeWidth: 0 }}
-                stroke="#ff6b6b"
-                strokeWidth={2}
-              />
-              <Line
-                dataKey="feeCut"
-                name="Fee Cut"
-                type="stepAfter"
-                dot={{ r: 2, strokeWidth: 0, fill: "#4ecdc4" }}
-                activeDot={{ r: 4, strokeWidth: 0 }}
-                stroke="#4ecdc4"
-                strokeWidth={2}
-              />
-            </LineChart>
-          </ResponsiveContainer>
-        )}
-      </Box>
-    </Card>
+              {/* Header overlay */}
+              <Box css={{ position: "absolute", zIndex: 3 }}>
+                <ExplorerTooltip
+                  multiline
+                  side="bottom"
+                  content="Historical changes to the orchestrator's reward cut and fee cut over time. Large sudden changes may indicate malicious behavior."
+                >
+                  <Flex css={{ alignItems: "center" }}>
+                    <Text
+                      css={{
+                        fontWeight: 600,
+                        fontSize: "$2",
+                        color: "white",
+                      }}
+                    >
+                      Reward & Fee Cut History
+                    </Text>
+                    <Box css={{ marginLeft: "$1" }}>
+                      <Box
+                        as={QuestionMarkCircledIcon}
+                        css={{ color: "$neutral11" }}
+                      />
+                    </Box>
+                  </Flex>
+                </ExplorerTooltip>
+                <Flex css={{ gap: "$3", marginTop: "$1" }}>
+                  <Flex css={{ alignItems: "center", gap: "$1" }}>
+                    <Box
+                      css={{
+                        width: 8,
+                        height: 8,
+                        borderRadius: "50%",
+                        backgroundColor: "#ff6b6b",
+                      }}
+                    />
+                    <Text
+                      css={{
+                        fontWeight: 600,
+                        fontSize: "$3",
+                        color: "white",
+                      }}
+                    >
+                      {hovered ? hovered.rewardCut : currentValues.rewardCut}
+                    </Text>
+                  </Flex>
+                  <Flex css={{ alignItems: "center", gap: "$1" }}>
+                    <Box
+                      css={{
+                        width: 8,
+                        height: 8,
+                        borderRadius: "50%",
+                        backgroundColor: "#4ecdc4",
+                      }}
+                    />
+                    <Text
+                      css={{
+                        fontWeight: 600,
+                        fontSize: "$3",
+                        color: "white",
+                      }}
+                    >
+                      {hovered ? hovered.feeCut : currentValues.feeCut}
+                    </Text>
+                  </Flex>
+                </Flex>
+                {hovered?.date && (
+                  <Text
+                    css={{
+                      fontWeight: 600,
+                      fontSize: "$2",
+                      color: "white",
+                    }}
+                  >
+                    {hovered.date}
+                  </Text>
+                )}
+              </Box>
+
+              {/* Chart area */}
+              <Box css={{ paddingTop: 57, width: "100%", height: "100%" }}>
+                {loading || chartData.length === 0 ? (
+                  <Skeleton
+                    css={{ width: "100%", height: "100%", borderRadius: 8 }}
+                  />
+                ) : (
+                  <ResponsiveContainer width="100%" height="100%">
+                    <LineChart
+                      data={chartData}
+                      onMouseMove={(e) => {
+                        if (e?.activePayload?.[0]) {
+                          const d = e.activePayload[0].payload as ChartDatum;
+                          setHovered({
+                            rewardCut: `${d.rewardCut.toFixed(1)}%`,
+                            feeCut: `${d.feeCut.toFixed(1)}%`,
+                            date: dayjs
+                              .unix(d.timestamp)
+                              .format("MMM D, YYYY"),
+                          });
+                        }
+                      }}
+                      onMouseLeave={() => setHovered(null)}
+                    >
+                      <XAxis
+                        dataKey="timestamp"
+                        tick={CustomXAxisTick}
+                        interval="preserveStartEnd"
+                      />
+                      <YAxis
+                        width={35}
+                        orientation="right"
+                        tick={CustomYAxisTick}
+                        domain={[0, 100]}
+                      />
+                      <Tooltip content={<CustomTooltip />} />
+                      <Line
+                        dataKey="rewardCut"
+                        name="Reward Cut"
+                        type="stepAfter"
+                        dot={{ r: 2, strokeWidth: 0, fill: "#ff6b6b" }}
+                        activeDot={{ r: 4, strokeWidth: 0 }}
+                        stroke="#ff6b6b"
+                        strokeWidth={2}
+                      />
+                      <Line
+                        dataKey="feeCut"
+                        name="Fee Cut"
+                        type="stepAfter"
+                        dot={{ r: 2, strokeWidth: 0, fill: "#4ecdc4" }}
+                        activeDot={{ r: 4, strokeWidth: 0 }}
+                        stroke="#4ecdc4"
+                        strokeWidth={2}
+                      />
+                    </LineChart>
+                  </ResponsiveContainer>
+                )}
+              </Box>
+            </Box>
+          </Panel>
+        </Box>
+      </Flex>
+    </Box>
   );
 };
 

--- a/components/RewardCutHistory/index.tsx
+++ b/components/RewardCutHistory/index.tsx
@@ -4,7 +4,6 @@ import { Box, Flex, Skeleton, Text } from "@livepeer/design-system";
 import { QuestionMarkCircledIcon } from "@modulz/radix-icons";
 import { useRewardCutHistory } from "hooks/useRewardCutHistory";
 import { useEffect, useMemo, useState } from "react";
-import { FiAlertTriangle } from "react-icons/fi";
 import {
   Line,
   LineChart,
@@ -97,7 +96,7 @@ interface Props {
 }
 
 const RewardCutHistory = ({ transcoderId }: Props) => {
-  const { chartData, loading, warning } = useRewardCutHistory(transcoderId);
+  const { chartData, loading } = useRewardCutHistory(transcoderId);
 
   const defaultValues = useMemo(() => {
     if (!chartData.length) return { rewardCut: "N/A", feeCut: "N/A" };
@@ -130,43 +129,6 @@ const RewardCutHistory = ({ transcoderId }: Props) => {
 
   return (
     <Box>
-      {/* Warning Banner - above the chart grid */}
-      {warning && (
-        <Flex
-          role="alert"
-          css={{
-            alignItems: "center",
-            backgroundColor: "$amber3",
-            border: "1px solid $amber6",
-            borderRadius: 10,
-            padding: "$3",
-            marginBottom: "$3",
-            gap: "$2",
-          }}
-        >
-          <Box
-            as={FiAlertTriangle}
-            aria-hidden="true"
-            css={{
-              color: "$amber11",
-              flexShrink: 0,
-              width: 16,
-              height: 16,
-            }}
-          />
-          <Text
-            css={{
-              fontSize: "$2",
-              color: "$amber11",
-              fontWeight: 400,
-              lineHeight: 1.4,
-            }}
-          >
-            {warning.message}
-          </Text>
-        </Flex>
-      )}
-
       {/* Chart grid - matches homepage layout */}
       <Flex
         css={{

--- a/components/RewardCutHistory/index.tsx
+++ b/components/RewardCutHistory/index.tsx
@@ -322,7 +322,7 @@ const RewardCutHistory = ({ transcoderId }: Props) => {
                         interval="preserveStartEnd"
                       />
                       <YAxis
-                        width={35}
+                        width={40}
                         orientation="right"
                         tick={CustomizedYAxisTick}
                         domain={[0, 100]}

--- a/components/RewardCutHistory/index.tsx
+++ b/components/RewardCutHistory/index.tsx
@@ -4,6 +4,7 @@ import { Box, Flex, Skeleton, Text } from "@livepeer/design-system";
 import { QuestionMarkCircledIcon } from "@modulz/radix-icons";
 import { useRewardCutHistory } from "hooks/useRewardCutHistory";
 import { useEffect, useMemo, useState } from "react";
+import { FiAlertTriangle } from "react-icons/fi";
 import {
   Line,
   LineChart,
@@ -96,7 +97,7 @@ interface Props {
 }
 
 const RewardCutHistory = ({ transcoderId }: Props) => {
-  const { chartData, loading } = useRewardCutHistory(transcoderId);
+  const { chartData, loading, warning } = useRewardCutHistory(transcoderId);
 
   const defaultValues = useMemo(() => {
     if (!chartData.length) return { rewardCut: "N/A", feeCut: "N/A" };
@@ -134,7 +135,9 @@ const RewardCutHistory = ({ transcoderId }: Props) => {
         css={{
           backgroundColor: "$panel",
           borderRadius: "$4",
-          border: "1px solid $colors$neutral4",
+          border: warning
+            ? "1px solid $amber6"
+            : "1px solid $colors$neutral4",
           overflow: "visible",
           marginBottom: "$4",
         }}
@@ -160,29 +163,55 @@ const RewardCutHistory = ({ transcoderId }: Props) => {
             >
               {/* Header overlay - matches ExplorerChart's absolute header */}
               <Box css={{ position: "absolute", zIndex: 3 }}>
-                <ExplorerTooltip
-                  multiline
-                  side="bottom"
-                  content="Historical changes to the orchestrator's reward cut and fee cut over time. Large sudden changes may indicate malicious behavior."
-                >
-                  <Flex css={{ alignItems: "center" }}>
-                    <Text
-                      css={{
-                        fontWeight: 600,
-                        fontSize: "$2",
-                        color: "white",
-                      }}
+                <Flex css={{ alignItems: "center" }}>
+                  <ExplorerTooltip
+                    multiline
+                    side="bottom"
+                    content="Historical changes to the orchestrator's reward cut and fee cut over time. Large sudden changes may indicate malicious behavior."
+                  >
+                    <Flex css={{ alignItems: "center" }}>
+                      <Text
+                        css={{
+                          fontWeight: 600,
+                          fontSize: "$2",
+                          color: "white",
+                        }}
+                      >
+                        Reward & Fee Cut History
+                      </Text>
+                      <Box css={{ marginLeft: "$1" }}>
+                        <Box
+                          as={QuestionMarkCircledIcon}
+                          css={{ color: "$neutral11" }}
+                        />
+                      </Box>
+                    </Flex>
+                  </ExplorerTooltip>
+                  {warning && (
+                    <ExplorerTooltip
+                      multiline
+                      side="bottom"
+                      content={warning.message}
                     >
-                      Reward & Fee Cut History
-                    </Text>
-                    <Box css={{ marginLeft: "$1" }}>
                       <Box
-                        as={QuestionMarkCircledIcon}
-                        css={{ color: "$neutral11" }}
-                      />
-                    </Box>
-                  </Flex>
-                </ExplorerTooltip>
+                        css={{
+                          marginLeft: "$1",
+                          display: "flex",
+                          alignItems: "center",
+                        }}
+                      >
+                        <Box
+                          as={FiAlertTriangle}
+                          css={{
+                            color: "$amber11",
+                            width: 14,
+                            height: 14,
+                          }}
+                        />
+                      </Box>
+                    </ExplorerTooltip>
+                  )}
+                </Flex>
                 <Flex>
                   {loading || (chartData?.length || 0) <= 0 ? (
                     <Skeleton

--- a/components/RewardCutHistory/index.tsx
+++ b/components/RewardCutHistory/index.tsx
@@ -131,12 +131,26 @@ const RewardCutHistory = ({ transcoderId }: Props) => {
   });
 
   const chartData = useMemo<ChartDatum[]>(() => {
-    if (!data?.transcoderUpdateEvents) return [];
-    return data.transcoderUpdateEvents.map((event) => ({
+    if (!data?.transcoderUpdateEvents?.length) return [];
+    const events = data.transcoderUpdateEvents.map((event) => ({
       timestamp: event.timestamp,
       rewardCut: (Number(event.rewardCut) / 1000000) * 100, // 1000000 = 100%
       feeCut: (1 - Number(event.feeShare) / 1000000) * 100, // feeShare is inverse of feeCut
     }));
+
+    // Add a "now" anchor point with the most recent values so the chart
+    // extends to the present day instead of ending at the last change
+    const last = events[events.length - 1];
+    const now = Math.floor(Date.now() / 1000);
+    if (now - last.timestamp > 86400) {
+      events.push({
+        timestamp: now,
+        rewardCut: last.rewardCut,
+        feeCut: last.feeCut,
+      });
+    }
+
+    return events;
   }, [data]);
 
   const warning = useMemo(() => {

--- a/hooks/useRewardCutHistory.tsx
+++ b/hooks/useRewardCutHistory.tsx
@@ -1,0 +1,88 @@
+import {
+  OrderDirection,
+  TranscoderUpdateEvent_OrderBy,
+  useTranscoderUpdateEventsQuery,
+} from "apollo";
+import { useMemo } from "react";
+
+// Only flag increases that hurt delegators (orch taking more).
+// Decreases are good for delegators and should not trigger warnings.
+const MALICIOUS_INCREASE_THRESHOLD = 50; // 50+ percentage point increase in one change
+
+type CutDataPoint = {
+  timestamp: number;
+  rewardCut: number;
+  feeCut: number;
+};
+
+type Warning = {
+  message: string;
+} | null;
+
+export function useRewardCutHistory(transcoderId?: string) {
+  const { data, loading } = useTranscoderUpdateEventsQuery({
+    variables: {
+      where: {
+        delegate: transcoderId,
+      },
+      first: 1000,
+      orderBy: TranscoderUpdateEvent_OrderBy.Timestamp,
+      orderDirection: OrderDirection.Asc,
+    },
+    skip: !transcoderId,
+  });
+
+  const chartData = useMemo<CutDataPoint[]>(() => {
+    if (!data?.transcoderUpdateEvents?.length) return [];
+    const events = data.transcoderUpdateEvents.map((event) => ({
+      timestamp: event.timestamp,
+      rewardCut: (Number(event.rewardCut) / 1000000) * 100,
+      feeCut: (1 - Number(event.feeShare) / 1000000) * 100,
+    }));
+
+    // Add a "now" anchor point with the most recent values so the chart
+    // extends to the present day instead of ending at the last change
+    const last = events[events.length - 1];
+    const now = Math.floor(Date.now() / 1000);
+    if (now - last.timestamp > 86400) {
+      events.push({
+        timestamp: now,
+        rewardCut: last.rewardCut,
+        feeCut: last.feeCut,
+      });
+    }
+
+    return events;
+  }, [data]);
+
+  const warning = useMemo<Warning>(() => {
+    if (chartData.length < 2) return null;
+
+    let worstRewardIncrease = 0;
+    let worstFeeIncrease = 0;
+
+    for (let i = 1; i < chartData.length; i++) {
+      // Positive = increase = bad for delegators
+      const rewardIncrease =
+        chartData[i].rewardCut - chartData[i - 1].rewardCut;
+      const feeIncrease = chartData[i].feeCut - chartData[i - 1].feeCut;
+
+      worstRewardIncrease = Math.max(worstRewardIncrease, rewardIncrease);
+      worstFeeIncrease = Math.max(worstFeeIncrease, feeIncrease);
+    }
+
+    if (
+      worstRewardIncrease >= MALICIOUS_INCREASE_THRESHOLD ||
+      worstFeeIncrease >= MALICIOUS_INCREASE_THRESHOLD
+    ) {
+      return {
+        message:
+          "This orchestrator has a history of making large increases to their cut percentages. This may indicate a bait-and-switch strategy. Review the chart below before delegating.",
+      };
+    }
+
+    return null;
+  }, [chartData]);
+
+  return { chartData, loading, warning };
+}

--- a/layouts/account.tsx
+++ b/layouts/account.tsx
@@ -14,7 +14,6 @@ import {
   Container,
   Flex,
   Link as A,
-  Text,
 } from "@livepeer/design-system";
 import {
   AccountQueryResult,
@@ -22,12 +21,10 @@ import {
   useAccountQuery,
 } from "apollo";
 import { useBondingManagerAddress } from "hooks/useContracts";
-import { useRewardCutHistory } from "hooks/useRewardCutHistory";
 import dynamic from "next/dynamic";
 import Link from "next/link";
 import { useRouter } from "next/router";
 import { useEffect, useMemo, useState } from "react";
-import { FiAlertTriangle } from "react-icons/fi";
 import { useWindowSize } from "react-use";
 import { useReadContract } from "wagmi";
 
@@ -185,10 +182,6 @@ const AccountLayout = ({
     ]
   );
 
-  const { warning } = useRewardCutHistory(
-    isOrchestrator ? accountId : undefined
-  );
-
   useEffect(() => {
     setSelectedStakingAction("delegate");
   }, [setSelectedStakingAction]);
@@ -215,42 +208,6 @@ const AccountLayout = ({
             isMyAccount={isMyAccount}
             identity={identity}
           />
-          {isOrchestrator && warning && (
-            <Flex
-              role="alert"
-              css={{
-                alignItems: "center",
-                backgroundColor: "$amber3",
-                border: "1px solid $amber6",
-                borderRadius: 10,
-                padding: "$3",
-                marginTop: "$4",
-                marginBottom: "$3",
-                gap: "$2",
-              }}
-            >
-              <Box
-                as={FiAlertTriangle}
-                aria-hidden="true"
-                css={{
-                  color: "$amber11",
-                  flexShrink: 0,
-                  width: 16,
-                  height: 16,
-                }}
-              />
-              <Text
-                css={{
-                  fontSize: "$2",
-                  color: "$amber11",
-                  fontWeight: 400,
-                  lineHeight: 1.4,
-                }}
-              >
-                {warning.message}
-              </Text>
-            </Flex>
-          )}
           <Flex
             css={{
               display: "flex",

--- a/layouts/account.tsx
+++ b/layouts/account.tsx
@@ -14,6 +14,7 @@ import {
   Container,
   Flex,
   Link as A,
+  Text,
 } from "@livepeer/design-system";
 import {
   AccountQueryResult,
@@ -21,10 +22,12 @@ import {
   useAccountQuery,
 } from "apollo";
 import { useBondingManagerAddress } from "hooks/useContracts";
+import { useRewardCutHistory } from "hooks/useRewardCutHistory";
 import dynamic from "next/dynamic";
 import Link from "next/link";
 import { useRouter } from "next/router";
 import { useEffect, useMemo, useState } from "react";
+import { FiAlertTriangle } from "react-icons/fi";
 import { useWindowSize } from "react-use";
 import { useReadContract } from "wagmi";
 
@@ -182,6 +185,10 @@ const AccountLayout = ({
     ]
   );
 
+  const { warning } = useRewardCutHistory(
+    isOrchestrator ? accountId : undefined
+  );
+
   useEffect(() => {
     setSelectedStakingAction("delegate");
   }, [setSelectedStakingAction]);
@@ -208,6 +215,42 @@ const AccountLayout = ({
             isMyAccount={isMyAccount}
             identity={identity}
           />
+          {isOrchestrator && warning && (
+            <Flex
+              role="alert"
+              css={{
+                alignItems: "center",
+                backgroundColor: "$amber3",
+                border: "1px solid $amber6",
+                borderRadius: 10,
+                padding: "$3",
+                marginTop: "$4",
+                marginBottom: "$3",
+                gap: "$2",
+              }}
+            >
+              <Box
+                as={FiAlertTriangle}
+                aria-hidden="true"
+                css={{
+                  color: "$amber11",
+                  flexShrink: 0,
+                  width: 16,
+                  height: 16,
+                }}
+              />
+              <Text
+                css={{
+                  fontSize: "$2",
+                  color: "$amber11",
+                  fontWeight: 400,
+                  lineHeight: 1.4,
+                }}
+              >
+                {warning.message}
+              </Text>
+            </Flex>
+          )}
           <Flex
             css={{
               display: "flex",

--- a/queries/transcoderUpdateEvents.graphql
+++ b/queries/transcoderUpdateEvents.graphql
@@ -1,0 +1,24 @@
+query transcoderUpdateEvents(
+  $where: TranscoderUpdateEvent_filter
+  $first: Int
+  $orderBy: TranscoderUpdateEvent_orderBy
+  $orderDirection: OrderDirection
+) {
+  transcoderUpdateEvents(
+    where: $where
+    first: $first
+    orderBy: $orderBy
+    orderDirection: $orderDirection
+  ) {
+    id
+    rewardCut
+    feeShare
+    timestamp
+    round {
+      id
+    }
+    transaction {
+      id
+    }
+  }
+}


### PR DESCRIPTION
Adds a dual-line chart (recharts) showing historical reward cut and fee
cut changes on the orchestrator detail page. Queries TranscoderUpdateEvents
from the subgraph filtered by orchestrator. Includes a warning banner
when large swings (50%+ points) are detected, helping delegators identify
potential bait-and-switch behavior.

https://claude.ai/code/session_01Su4CTFo3t3Q22rkZjFnfAS