### PR TITLE
feat: warn on reward/fee cut charts when cuts change frequently

### DIFF
--- a/apollo/subgraph.ts
+++ b/apollo/subgraph.ts
@@ -10843,6 +10843,50 @@ export function useTranscoderActivatedEventsLazyQuery(baseOptions?: Apollo.LazyQ
 export type TranscoderActivatedEventsQueryHookResult = ReturnType<typeof useTranscoderActivatedEventsQuery>;
 export type TranscoderActivatedEventsLazyQueryHookResult = ReturnType<typeof useTranscoderActivatedEventsLazyQuery>;
 export type TranscoderActivatedEventsQueryResult = Apollo.QueryResult<TranscoderActivatedEventsQuery, TranscoderActivatedEventsQueryVariables>;
+
+export type TranscoderUpdateEventsQueryVariables = Exact<{
+  where?: InputMaybe<TranscoderUpdateEvent_Filter>;
+  first?: InputMaybe<Scalars['Int']>;
+  orderBy?: InputMaybe<TranscoderUpdateEvent_OrderBy>;
+  orderDirection?: InputMaybe<OrderDirection>;
+}>;
+
+export type TranscoderUpdateEventsQuery = { __typename: 'Query', transcoderUpdateEvents: Array<{ __typename: 'TranscoderUpdateEvent', id: string, rewardCut: string, feeShare: string, timestamp: number, round: { __typename: 'Round', id: string }, transaction: { __typename: 'Transaction', id: string } }> };
+
+export const TranscoderUpdateEventsDocument = gql`
+    query transcoderUpdateEvents($where: TranscoderUpdateEvent_filter, $first: Int, $orderBy: TranscoderUpdateEvent_orderBy, $orderDirection: OrderDirection) {
+  transcoderUpdateEvents(
+    where: $where
+    first: $first
+    orderBy: $orderBy
+    orderDirection: $orderDirection
+  ) {
+    id
+    rewardCut
+    feeShare
+    timestamp
+    round {
+      id
+    }
+    transaction {
+      id
+    }
+  }
+}
+    `;
+
+export function useTranscoderUpdateEventsQuery(baseOptions?: Apollo.QueryHookOptions<TranscoderUpdateEventsQuery, TranscoderUpdateEventsQueryVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useQuery<TranscoderUpdateEventsQuery, TranscoderUpdateEventsQueryVariables>(TranscoderUpdateEventsDocument, options);
+      }
+export function useTranscoderUpdateEventsLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<TranscoderUpdateEventsQuery, TranscoderUpdateEventsQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useLazyQuery<TranscoderUpdateEventsQuery, TranscoderUpdateEventsQueryVariables>(TranscoderUpdateEventsDocument, options);
+        }
+export type TranscoderUpdateEventsQueryHookResult = ReturnType<typeof useTranscoderUpdateEventsQuery>;
+export type TranscoderUpdateEventsLazyQueryHookResult = ReturnType<typeof useTranscoderUpdateEventsLazyQuery>;
+export type TranscoderUpdateEventsQueryResult = Apollo.QueryResult<TranscoderUpdateEventsQuery, TranscoderUpdateEventsQueryVariables>;
+
 export const TreasuryProposalDocument = gql`
     query treasuryProposal($id: ID!) {
   treasuryProposal(id: $id) {

--- a/components/DelegatingWidget/Delegate.tsx
+++ b/components/DelegatingWidget/Delegate.tsx
@@ -18,6 +18,7 @@ const Delegate = ({
   to,
   amount,
   isTransferStake,
+  isMyTranscoder,
   tokenBalance,
   transferAllowance,
   reset,
@@ -168,7 +169,7 @@ const Delegate = ({
     );
   }
 
-  const cutChangeNotice = (
+  const cutChangeNotice = isMyTranscoder ? null : (
     <Flex
       css={{
         alignItems: "center",
@@ -184,7 +185,7 @@ const Delegate = ({
         css={{ color: "white", flexShrink: 0, width: 16, height: 16 }}
       />
       <Text css={{ fontSize: "$2", color: "white", lineHeight: 1.5 }}>
-        Please ensure you checked the reward & fee cut history before
+        Please ensure you have checked the reward & fee cut history before
         delegating.
       </Text>
     </Flex>

--- a/components/DelegatingWidget/Delegate.tsx
+++ b/components/DelegatingWidget/Delegate.tsx
@@ -1,7 +1,8 @@
 import { bondingManager } from "@lib/api/abis/main/BondingManager";
 import { livepeerToken } from "@lib/api/abis/main/LivepeerToken";
 import { MAXIMUM_VALUE_UINT256 } from "@lib/utils";
-import { Box, Button } from "@livepeer/design-system";
+import { Box, Button, Flex, Text } from "@livepeer/design-system";
+import { InfoCircledIcon } from "@radix-ui/react-icons";
 import {
   useBondingManagerAddress,
   useLivepeerTokenAddress,
@@ -167,48 +168,80 @@ const Delegate = ({
     );
   }
 
+  const cutChangeNotice = (
+    <Flex
+      css={{
+        alignItems: "center",
+        gap: "$3",
+        padding: "$3",
+        marginBottom: "$3",
+        borderRadius: "$3",
+        background: "$neutral3",
+      }}
+    >
+      <Box
+        as={InfoCircledIcon}
+        css={{ color: "white", flexShrink: 0, width: 16, height: 16 }}
+      />
+      <Text css={{ fontSize: "$2", color: "white", lineHeight: 1.5 }}>
+        Please ensure you checked the reward & fee cut history before
+        delegating.
+      </Text>
+    </Flex>
+  );
+
   if (showApproveFlow) {
     return (
-      <Box>
-        <Box
-          css={{ display: "grid", gap: "$3", gridTemplateColumns: "1fr 1fr" }}
-        >
-          <Button
-            size="4"
-            variant="primary"
-            disabled={sufficientTransferAllowance}
-            onClick={onApprove}
-            css={{ width: "100%" }}
+      <>
+        {cutChangeNotice}
+        <Box>
+          <Box
+            css={{
+              display: "grid",
+              gap: "$3",
+              gridTemplateColumns: "1fr 1fr",
+            }}
           >
-            Approve
-          </Button>
-          <Button
-            size="4"
-            disabled={!sufficientTransferAllowance}
-            variant="primary"
-            onClick={onDelegate}
-            css={{ width: "100%" }}
-          >
-            {+amount >= 0 && isTransferStake ? "Switch" : "Delegate"}
-          </Button>
+            <Button
+              size="4"
+              variant="primary"
+              disabled={sufficientTransferAllowance}
+              onClick={onApprove}
+              css={{ width: "100%" }}
+            >
+              Approve
+            </Button>
+            <Button
+              size="4"
+              disabled={!sufficientTransferAllowance}
+              variant="primary"
+              onClick={onDelegate}
+              css={{ width: "100%" }}
+            >
+              {+amount >= 0 && isTransferStake ? "Switch" : "Delegate"}
+            </Button>
+          </Box>
+          <ProgressSteps
+            steps={[sufficientTransferAllowance]}
+            css={{ mt: "$3" }}
+          />
         </Box>
-        <ProgressSteps
-          steps={[sufficientTransferAllowance]}
-          css={{ mt: "$3" }}
-        />
-      </Box>
+      </>
     );
   }
 
   return (
-    <Button
-      size="4"
-      onClick={onDelegate}
-      variant="primary"
-      css={{ width: "100%" }}
-    >
-      {+amount >= 0 && isTransferStake ? "Move Delegated Stake" : "Delegate"}
-    </Button>
+    <>
+      {cutChangeNotice}
+      <Button
+        size="4"
+        onClick={onDelegate}
+        variant="primary"
+        css={{ width: "100%" }}
+      >
+        {+amount >= 0 && isTransferStake ? "Move Delegated Stake" : "Delegate"}
+      </Button>
+    </>
   );
 };
 

--- a/components/DelegatingWidget/Footer.tsx
+++ b/components/DelegatingWidget/Footer.tsx
@@ -165,6 +165,7 @@ const Footer = ({
           to={transcoder?.id}
           amount={amount}
           isTransferStake={isTransferStake}
+          isMyTranscoder={isMyTranscoder}
           tokenBalance={tokenBalance}
           transferAllowance={transferAllowance}
           reset={reset}

--- a/components/ExplorerChart/index.tsx
+++ b/components/ExplorerChart/index.tsx
@@ -63,11 +63,13 @@ const ExplorerChart = ({
   basePercentChange,
   unit = "none",
   type,
+  lineCurve = "monotone",
+  yDomain,
   grouping = "day",
   onToggleGrouping,
 }: {
   title: string;
-  tooltip: string;
+  tooltip: React.ReactNode;
   base: number;
   basePercentChange: number;
   data: ChartDatum[];
@@ -80,6 +82,8 @@ const ExplorerChart = ({
     | "small-unitless"
     | "none";
   type: "bar" | "line";
+  lineCurve?: "monotone" | "stepAfter" | "linear";
+  yDomain?: [number | "auto" | "dataMin", number | "auto" | "dataMax"];
   grouping?: Group;
   onToggleGrouping?: (grouping: Group) => void;
 }) => {
@@ -223,7 +227,7 @@ const ExplorerChart = ({
       unit === "small-percent"
         ? 45
         : unit === "percent"
-        ? 35
+        ? 42
         : unit === "minutes"
         ? 35
         : unit === "eth"
@@ -245,23 +249,7 @@ const ExplorerChart = ({
         <ExplorerTooltip
           multiline
           side="bottom"
-          content={
-            tooltip ? (
-              <>
-                <div>{tooltip}</div>
-                <br />
-                <div>
-                  {`The estimation methodology was updated on 8/21/23. `}
-                  <a href="https://forum.livepeer.org/t/livepeer-explorer-minutes-estimation-methodology/2140">
-                    Read more about the changes
-                  </a>
-                  {"."}
-                </div>
-              </>
-            ) : (
-              <></>
-            )
-          }
+          content={tooltip ? <div>{tooltip}</div> : <></>}
         >
           <Flex
             css={{
@@ -479,13 +467,13 @@ const ExplorerChart = ({
                 width={widthYAxis}
                 orientation="right"
                 tick={CustomizedYAxisTick}
-                domain={["auto", "auto"]}
+                domain={yDomain ?? ["auto", "auto"]}
               />
               <ReTooltip content={CustomContentOfTooltip} />
 
               <Line
                 dataKey="y"
-                type="monotone"
+                type={lineCurve}
                 dot={{ r: 0, strokeWidth: 0 }}
                 activeDot={{ r: 3, strokeWidth: 0 }}
                 stroke="rgba(0, 235, 136, 0.8)"

--- a/components/ExplorerChart/index.tsx
+++ b/components/ExplorerChart/index.tsx
@@ -58,6 +58,7 @@ export type Group = "day" | "week" | "year" | "all";
 const ExplorerChart = ({
   title,
   tooltip,
+  titleTrailing,
   data,
   base,
   basePercentChange,
@@ -70,6 +71,7 @@ const ExplorerChart = ({
 }: {
   title: string;
   tooltip: React.ReactNode;
+  titleTrailing?: React.ReactNode;
   base: number;
   basePercentChange: number;
   data: ChartDatum[];
@@ -246,35 +248,40 @@ const ExplorerChart = ({
           zIndex: 3,
         }}
       >
-        <ExplorerTooltip
-          multiline
-          side="bottom"
-          content={tooltip ? <div>{tooltip}</div> : <></>}
-        >
-          <Flex
-            css={{
-              alignItems: "center",
-            }}
+        <Flex css={{ alignItems: "center" }}>
+          <ExplorerTooltip
+            multiline
+            side="bottom"
+            content={tooltip ? <div>{tooltip}</div> : <></>}
           >
-            <Text
+            <Flex
               css={{
-                fontWeight: 600,
-                fontSize: "$2",
-                color: "white",
+                alignItems: "center",
               }}
             >
-              {title}
-            </Text>
-            {tooltip && (
-              <Box css={{ marginLeft: "$1" }}>
-                <Box
-                  as={QuestionMarkCircledIcon}
-                  css={{ color: "$neutral11" }}
-                />
-              </Box>
-            )}
-          </Flex>
-        </ExplorerTooltip>
+              <Text
+                css={{
+                  fontWeight: 600,
+                  fontSize: "$2",
+                  color: "white",
+                }}
+              >
+                {title}
+              </Text>
+              {tooltip && (
+                <Box css={{ marginLeft: "$1" }}>
+                  <Box
+                    as={QuestionMarkCircledIcon}
+                    css={{ color: "$neutral11" }}
+                  />
+                </Box>
+              )}
+            </Flex>
+          </ExplorerTooltip>
+          {titleTrailing && (
+            <Box css={{ marginLeft: "$1" }}>{titleTrailing}</Box>
+          )}
+        </Flex>
         <Flex>
           {(data?.length || 0) <= 0 ? (
             <Skeleton css={{ marginTop: "$1", width: "100%", height: 20 }} />

--- a/components/OrchestratingView/index.tsx
+++ b/components/OrchestratingView/index.tsx
@@ -1,3 +1,4 @@
+import OrchestratorCutHistory from "@components/OrchestratorCutHistory";
 import Stat from "@components/Stat";
 import dayjs from "@lib/dayjs";
 import { Box, Flex, Link as A, Text } from "@livepeer/design-system";
@@ -250,21 +251,6 @@ const Index = ({ currentRound, transcoder, isActive }: Props) => {
         /> */}
         <Stat
           className="masonry-grid_item"
-          label="Fee Cut"
-          tooltip={
-            "The percent of the transcoding fees which are kept by the orchestrator, with the remainder distributed to its delegators by percent stake."
-          }
-          value={
-            transcoder?.feeShare
-              ? numbro(1 - +(transcoder?.feeShare || 0) / 1000000).format({
-                  output: "percent",
-                  mantissa: 0,
-                })
-              : "N/A"
-          }
-        />
-        <Stat
-          className="masonry-grid_item"
           label="Reward Cut"
           tooltip={
             "The percent of the inflationary reward fees which are kept by the orchestrator, with the remainder distributed to its delegators by percent stake."
@@ -277,6 +263,21 @@ const Index = ({ currentRound, transcoder, isActive }: Props) => {
                     output: "percent",
                     mantissa: 0,
                   })
+              : "N/A"
+          }
+        />
+        <Stat
+          className="masonry-grid_item"
+          label="Fee Cut"
+          tooltip={
+            "The percent of the transcoding fees which are kept by the orchestrator, with the remainder distributed to its delegators by percent stake."
+          }
+          value={
+            transcoder?.feeShare
+              ? numbro(1 - +(transcoder?.feeShare || 0) / 1000000).format({
+                  output: "percent",
+                  mantissa: 0,
+                })
               : "N/A"
           }
         />
@@ -329,112 +330,110 @@ const Index = ({ currentRound, transcoder, isActive }: Props) => {
             }
           />
         )}
-        <A
-          as={Link}
-          href={`/accounts/${transcoder?.id}/history`}
-          passHref
-          className="masonry-grid_item"
-          css={{
-            display: "block",
+      </Masonry>
+      <A
+        as={Link}
+        href={`/accounts/${transcoder?.id}/history`}
+        passHref
+        css={{
+          display: "block",
+          textDecoration: "none",
+          marginBottom: "$3",
+          "&:hover": {
             textDecoration: "none",
-            "&:hover": {
-              textDecoration: "none",
-              ".see-history": {
-                textDecoration: "underline",
-                color: "$primary11",
-                transition: "color .3s",
-              },
+            ".see-history": {
+              textDecoration: "underline",
+              color: "$primary11",
+              transition: "color .3s",
             },
-          }}
-        >
-          <Stat
-            label="Treasury Governance Participation"
-            variant="interactive"
-            tooltip={
-              <Box>
-                Number of proposals voted on relative to the number of proposals
-                the orchestrator was eligible for while active.
-              </Box>
-            }
-            value={
-              govStats ? (
-                <Flex css={{ alignItems: "baseline", gap: "$1" }}>
-                  <Box css={{ color: "$hiContrast" }}>{govStats.voted}</Box>
-                  <Box
-                    css={{
-                      fontSize: "$3",
-                      color: "$neutral11",
-                      fontWeight: 500,
-                    }}
-                  >
-                    / {govStats.eligible} Proposals
-                  </Box>
-                </Flex>
-              ) : (
-                "N/A"
-              )
-            }
-            meta={
-              <Box css={{ width: "100%", marginTop: "$2" }}>
-                {govStats && (
-                  <Box
-                    css={{
-                      width: "100%",
-                      height: 4,
-                      backgroundColor: "$neutral4",
-                      borderRadius: "$2",
-                      overflow: "hidden",
-                      marginBottom: "$2",
-                    }}
-                  >
-                    <Box
-                      css={{
-                        width: `${(govStats.voted / govStats.eligible) * 100}%`,
-                        height: "100%",
-                        backgroundColor: "$primary11",
-                      }}
-                    />
-                  </Box>
-                )}
-                <Flex
+          },
+        }}
+      >
+        <Stat
+          label="Treasury Governance Participation"
+          variant="interactive"
+          tooltip={
+            <Box>
+              Number of proposals voted on relative to the number of proposals
+              the orchestrator was eligible for while active.
+            </Box>
+          }
+          value={
+            govStats ? (
+              <Flex css={{ alignItems: "baseline", gap: "$1" }}>
+                <Box css={{ color: "$hiContrast" }}>{govStats.voted}</Box>
+                <Box
                   css={{
-                    alignItems: "center",
-                    justifyContent: "space-between",
-                    width: "100%",
+                    fontSize: "$3",
+                    color: "$neutral11",
+                    fontWeight: 500,
                   }}
                 >
-                  {govStats && (
-                    <Text
-                      size="2"
-                      css={{ color: "$neutral11", fontWeight: 600 }}
-                    >
-                      {numbro(govStats.voted / govStats.eligible).format({
-                        output: "percent",
-                        mantissa: 0,
-                      })}{" "}
-                      Participation
-                    </Text>
-                  )}
-                  <Text
-                    className="see-history"
-                    size="2"
+                  / {govStats.eligible} Proposals
+                </Box>
+              </Flex>
+            ) : (
+              "N/A"
+            )
+          }
+          meta={
+            <Box css={{ width: "100%", marginTop: "$2" }}>
+              {govStats && (
+                <Box
+                  css={{
+                    width: "100%",
+                    height: 4,
+                    backgroundColor: "$neutral4",
+                    borderRadius: "$2",
+                    overflow: "hidden",
+                    marginBottom: "$2",
+                  }}
+                >
+                  <Box
                     css={{
-                      color: "$primary11",
-                      fontWeight: 600,
-                      display: "flex",
-                      alignItems: "center",
-                      gap: "$0.75",
+                      width: `${(govStats.voted / govStats.eligible) * 100}%`,
+                      height: "100%",
+                      backgroundColor: "$primary11",
                     }}
-                  >
-                    See history
-                    <Box as={ArrowTopRightIcon} width={15} height={15} />
+                  />
+                </Box>
+              )}
+              <Flex
+                css={{
+                  alignItems: "center",
+                  justifyContent: "space-between",
+                  width: "100%",
+                }}
+              >
+                {govStats && (
+                  <Text size="2" css={{ color: "$neutral11", fontWeight: 600 }}>
+                    {numbro(govStats.voted / govStats.eligible).format({
+                      output: "percent",
+                      mantissa: 0,
+                    })}{" "}
+                    Participation
                   </Text>
-                </Flex>
-              </Box>
-            }
-          />
-        </A>
-      </Masonry>
+                )}
+                <Text
+                  className="see-history"
+                  size="2"
+                  css={{
+                    color: "$primary11",
+                    fontWeight: 600,
+                    display: "flex",
+                    alignItems: "center",
+                    gap: "$0.75",
+                  }}
+                >
+                  See history
+                  <Box as={ArrowTopRightIcon} width={15} height={15} />
+                </Text>
+              </Flex>
+            </Box>
+          }
+        />
+      </A>
+      <OrchestratorCutHistory transcoder={transcoder} />
     </Box>
   );
 };

--- a/components/OrchestratorCutHistory/index.tsx
+++ b/components/OrchestratorCutHistory/index.tsx
@@ -1,0 +1,88 @@
+import ExplorerChart from "@components/ExplorerChart";
+import { Box, Flex } from "@livepeer/design-system";
+import type { AccountQueryResult } from "apollo";
+import { useOrchestratorCutHistory } from "hooks/useOrchestratorCutHistory";
+
+const Panel = ({ children }) => (
+  <Flex
+    css={{
+      minHeight: 240,
+      height: 240,
+      padding: "24px",
+      flexDirection: "column",
+      alignItems: "center",
+      justifyContent: "center",
+      border: "0.5px solid $colors$neutral4",
+      flex: 1,
+      width: "100%",
+    }}
+  >
+    {children}
+  </Flex>
+);
+
+interface Props {
+  transcoder?: NonNullable<AccountQueryResult["data"]>["transcoder"];
+}
+
+const OrchestratorCutHistory = ({ transcoder }: Props) => {
+  const { rewardCutData, feeCutData, baseRewardCut, baseFeeCut, loading } =
+    useOrchestratorCutHistory(transcoder);
+
+  // Hide when there's no orchestrator or no data to plot.
+  if (!transcoder?.id) return null;
+  if (!loading && rewardCutData.length === 0) return null;
+
+  return (
+    <Box css={{ marginBottom: "$3" }}>
+      <Flex
+        css={{
+          backgroundColor: "$panel",
+          borderRadius: "$4",
+          border: "1px solid $colors$neutral4",
+          overflow: "hidden",
+        }}
+      >
+        <Box
+          css={{
+            width: "100%",
+            display: "grid",
+            gridTemplateColumns: "1fr",
+            "@bp2": {
+              gridTemplateColumns: "1fr 1fr",
+            },
+          }}
+        >
+          <Panel>
+            <ExplorerChart
+              title="Reward Cut"
+              tooltip="The percent of inflationary rewards kept by the orchestrator over time."
+              data={rewardCutData}
+              base={baseRewardCut}
+              basePercentChange={0}
+              unit="percent"
+              type="line"
+              lineCurve="stepAfter"
+              yDomain={[0, 1]}
+            />
+          </Panel>
+          <Panel>
+            <ExplorerChart
+              title="Fee Cut"
+              tooltip="The percent of transcoding fees kept by the orchestrator over time."
+              data={feeCutData}
+              base={baseFeeCut}
+              basePercentChange={0}
+              unit="percent"
+              type="line"
+              lineCurve="stepAfter"
+              yDomain={[0, 1]}
+            />
+          </Panel>
+        </Box>
+      </Flex>
+    </Box>
+  );
+};
+
+export default OrchestratorCutHistory;

--- a/components/OrchestratorCutHistory/index.tsx
+++ b/components/OrchestratorCutHistory/index.tsx
@@ -1,7 +1,12 @@
 import ExplorerChart from "@components/ExplorerChart";
+import { ExplorerTooltip } from "@components/ExplorerTooltip";
 import { Box, Flex } from "@livepeer/design-system";
+import { ExclamationTriangleIcon } from "@radix-ui/react-icons";
 import type { AccountQueryResult } from "apollo";
-import { useOrchestratorCutHistory } from "hooks/useOrchestratorCutHistory";
+import {
+  FREQUENT_CUT_CHANGE_WINDOW_DAYS,
+  useOrchestratorCutHistory,
+} from "hooks/useOrchestratorCutHistory";
 
 const Panel = ({ children }) => (
   <Flex
@@ -21,13 +26,45 @@ const Panel = ({ children }) => (
   </Flex>
 );
 
+const FrequentChangeIndicator = ({
+  cutLabel,
+  count,
+}: {
+  cutLabel: string;
+  count: number;
+}) => (
+  <ExplorerTooltip
+    multiline
+    content={
+      <Box>
+        This orchestrator has changed their {cutLabel} {count} times in the last{" "}
+        {FREQUENT_CUT_CHANGE_WINDOW_DAYS} days. Frequent updates are worth
+        reviewing before delegating.
+      </Box>
+    }
+  >
+    <Box css={{ display: "flex", alignItems: "center" }}>
+      <Box as={ExclamationTriangleIcon} css={{ color: "$amber11" }} />
+    </Box>
+  </ExplorerTooltip>
+);
+
 interface Props {
   transcoder?: NonNullable<AccountQueryResult["data"]>["transcoder"];
 }
 
 const OrchestratorCutHistory = ({ transcoder }: Props) => {
-  const { rewardCutData, feeCutData, baseRewardCut, baseFeeCut, loading } =
-    useOrchestratorCutHistory(transcoder);
+  const {
+    rewardCutData,
+    feeCutData,
+    baseRewardCut,
+    baseFeeCut,
+    rewardCutChangeCount,
+    feeCutChangeCount,
+    hasFrequentRewardCutChanges,
+    hasFrequentFeeCutChanges,
+    loading,
+  } = useOrchestratorCutHistory(transcoder);
 
   // Hide when there's no orchestrator or no data to plot.
   if (!transcoder?.id) return null;
@@ -57,6 +94,14 @@ const OrchestratorCutHistory = ({ transcoder }: Props) => {
             <ExplorerChart
               title="Reward Cut"
               tooltip="The percent of inflationary rewards kept by the orchestrator over time."
+              titleTrailing={
+                hasFrequentRewardCutChanges ? (
+                  <FrequentChangeIndicator
+                    cutLabel="reward cut"
+                    count={rewardCutChangeCount}
+                  />
+                ) : undefined
+              }
               data={rewardCutData}
               base={baseRewardCut}
               basePercentChange={0}
@@ -70,6 +115,14 @@ const OrchestratorCutHistory = ({ transcoder }: Props) => {
             <ExplorerChart
               title="Fee Cut"
               tooltip="The percent of transcoding fees kept by the orchestrator over time."
+              titleTrailing={
+                hasFrequentFeeCutChanges ? (
+                  <FrequentChangeIndicator
+                    cutLabel="fee cut"
+                    count={feeCutChangeCount}
+                  />
+                ) : undefined
+              }
               data={feeCutData}
               base={baseFeeCut}
               basePercentChange={0}

--- a/hooks/useOrchestratorCutHistory.tsx
+++ b/hooks/useOrchestratorCutHistory.tsx
@@ -1,0 +1,102 @@
+import type { ChartDatum } from "@components/ExplorerChart";
+import type { AccountQueryResult } from "apollo";
+import {
+  OrderDirection,
+  TranscoderUpdateEvent_OrderBy,
+  useTranscoderUpdateEventsQuery,
+} from "apollo";
+import { useMemo } from "react";
+
+export type CutDataPoint = {
+  timestamp: number;
+  rewardCut: number;
+  feeCut: number;
+};
+
+type Transcoder = NonNullable<AccountQueryResult["data"]>["transcoder"];
+
+export function useOrchestratorCutHistory(transcoder?: Transcoder) {
+  const { data, loading } = useTranscoderUpdateEventsQuery({
+    variables: {
+      where: {
+        delegate: transcoder?.id,
+      },
+      first: 1000,
+      orderBy: TranscoderUpdateEvent_OrderBy.Timestamp,
+      orderDirection: OrderDirection.Asc,
+    },
+    skip: !transcoder?.id,
+  });
+
+  const chartData = useMemo<CutDataPoint[]>(() => {
+    const events: CutDataPoint[] = (data?.transcoderUpdateEvents ?? []).map(
+      (event) => ({
+        timestamp: event.timestamp,
+        rewardCut: (Number(event.rewardCut) / 1000000) * 100,
+        feeCut: (1 - Number(event.feeShare) / 1000000) * 100,
+      })
+    );
+
+    // No update events — synthesize a starting anchor from current
+    // on-chain values at activation time so the chart shows a flat line.
+    if (
+      events.length === 0 &&
+      transcoder?.activationTimestamp &&
+      transcoder?.rewardCut != null &&
+      transcoder?.feeShare != null
+    ) {
+      events.push({
+        timestamp: Number(transcoder.activationTimestamp),
+        rewardCut: (Number(transcoder.rewardCut) / 1000000) * 100,
+        feeCut: (1 - Number(transcoder.feeShare) / 1000000) * 100,
+      });
+    }
+
+    if (events.length === 0) return [];
+
+    // "Now" anchor so the chart line extends to the present day.
+    const last = events[events.length - 1];
+    // eslint-disable-next-line react-hooks/purity
+    const now = Math.floor(Date.now() / 1000);
+    if (now - last.timestamp > 86400) {
+      events.push({
+        timestamp: now,
+        rewardCut: last.rewardCut,
+        feeCut: last.feeCut,
+      });
+    }
+
+    return events;
+  }, [
+    data,
+    transcoder?.activationTimestamp,
+    transcoder?.rewardCut,
+    transcoder?.feeShare,
+  ]);
+
+  // ExplorerChart's percent unit expects decimals (0.05 = 5%).
+  const rewardCutData = useMemo<ChartDatum[]>(
+    () => chartData.map((d) => ({ x: d.timestamp, y: d.rewardCut / 100 })),
+    [chartData]
+  );
+  const feeCutData = useMemo<ChartDatum[]>(
+    () => chartData.map((d) => ({ x: d.timestamp, y: d.feeCut / 100 })),
+    [chartData]
+  );
+
+  const baseRewardCut = chartData.length
+    ? chartData[chartData.length - 1].rewardCut / 100
+    : 0;
+  const baseFeeCut = chartData.length
+    ? chartData[chartData.length - 1].feeCut / 100
+    : 0;
+
+  return {
+    chartData,
+    rewardCutData,
+    feeCutData,
+    baseRewardCut,
+    baseFeeCut,
+    loading,
+  };
+}

--- a/hooks/useOrchestratorCutHistory.tsx
+++ b/hooks/useOrchestratorCutHistory.tsx
@@ -15,6 +15,13 @@ export type CutDataPoint = {
 
 type Transcoder = NonNullable<AccountQueryResult["data"]>["transcoder"];
 
+// A warning is surfaced on the cut history charts when an orchestrator records
+// at least this many value transitions within the recent window. Kept
+// deliberately lenient — see the chart tooltip copy for why this is
+// informational rather than a judgement.
+export const FREQUENT_CUT_CHANGE_WINDOW_DAYS = 30;
+export const FREQUENT_CUT_CHANGE_MIN_COUNT = 3;
+
 export function useOrchestratorCutHistory(transcoder?: Transcoder) {
   const { data, loading } = useTranscoderUpdateEventsQuery({
     variables: {
@@ -91,12 +98,60 @@ export function useOrchestratorCutHistory(transcoder?: Transcoder) {
     ? chartData[chartData.length - 1].feeCut / 100
     : 0;
 
+  // Count how many times the reward / fee cut values actually changed
+  // within the recent window. We walk events in order so a transition that
+  // straddles the window boundary is still attributed to the in-window event.
+  const { rewardCutChangeCount, feeCutChangeCount } = useMemo(() => {
+    const events = data?.transcoderUpdateEvents ?? [];
+    const cutoff =
+      // eslint-disable-next-line react-hooks/purity
+      Math.floor(Date.now() / 1000) - FREQUENT_CUT_CHANGE_WINDOW_DAYS * 86400;
+
+    let rewardChanges = 0;
+    let feeChanges = 0;
+    let prevReward: string | undefined;
+    let prevFee: string | undefined;
+
+    for (const e of events) {
+      if (
+        e.timestamp >= cutoff &&
+        prevReward !== undefined &&
+        String(e.rewardCut) !== prevReward
+      ) {
+        rewardChanges += 1;
+      }
+      if (
+        e.timestamp >= cutoff &&
+        prevFee !== undefined &&
+        String(e.feeShare) !== prevFee
+      ) {
+        feeChanges += 1;
+      }
+      prevReward = String(e.rewardCut);
+      prevFee = String(e.feeShare);
+    }
+
+    return {
+      rewardCutChangeCount: rewardChanges,
+      feeCutChangeCount: feeChanges,
+    };
+  }, [data]);
+
+  const hasFrequentRewardCutChanges =
+    rewardCutChangeCount >= FREQUENT_CUT_CHANGE_MIN_COUNT;
+  const hasFrequentFeeCutChanges =
+    feeCutChangeCount >= FREQUENT_CUT_CHANGE_MIN_COUNT;
+
   return {
     chartData,
     rewardCutData,
     feeCutData,
     baseRewardCut,
     baseFeeCut,
+    rewardCutChangeCount,
+    feeCutChangeCount,
+    hasFrequentRewardCutChanges,
+    hasFrequentFeeCutChanges,
     loading,
   };
 }

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -196,9 +196,20 @@ const Charts = ({ chartData }: { chartData: HomeChartData | null }) => {
       </Panel>
       <Panel>
         <ExplorerChart
-          tooltip={`The ${
-            usageGrouping === "day" ? "daily" : "weekly"
-          } usage of the network in minutes.`}
+          tooltip={
+            <>
+              {`The ${
+                usageGrouping === "day" ? "daily" : "weekly"
+              } usage of the network in minutes.`}
+              <br />
+              <br />
+              {"The estimation methodology was updated on 8/21/23. "}
+              <a href="https://forum.livepeer.org/t/livepeer-explorer-minutes-estimation-methodology/2140">
+                Read more about the changes
+              </a>
+              {"."}
+            </>
+          }
           data={
             usageGrouping === "week"
               ? usageData.slice(-26)

--- a/queries/transcoderUpdateEvents.graphql
+++ b/queries/transcoderUpdateEvents.graphql
@@ -1,0 +1,24 @@
+query transcoderUpdateEvents(
+  $where: TranscoderUpdateEvent_filter
+  $first: Int
+  $orderBy: TranscoderUpdateEvent_orderBy
+  $orderDirection: OrderDirection
+) {
+  transcoderUpdateEvents(
+    where: $where
+    first: $first
+    orderBy: $orderBy
+    orderDirection: $orderDirection
+  ) {
+    id
+    rewardCut
+    feeShare
+    timestamp
+    round {
+      id
+    }
+    transaction {
+      id
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Stacked on livepeer/explorer#626 (the reward & fee cut history charts). Adds a small amber warning icon with a tooltip on top of each chart when the orchestrator has changed the corresponding cut ≥ 3 times in the last 30 days — same visual pattern as the self-redeem indicator in `BroadcastingView`.

The branch carries #626's three commits as a base; only the final commit (`998fda4 feat: warn on reward/fee cut charts when cuts change frequently`) is new in this PR. Once #626 merges upstream the base commits fall away.

## What's new

- `hooks/useOrchestratorCutHistory.tsx` — walks `transcoderUpdateEvents` ascending and counts reward-cut and fee-cut value *transitions* in the last 30 days. Carries the previous value across the window boundary so an edge transition still counts. Exposes `hasFrequentRewardCutChanges` / `hasFrequentFeeCutChanges` plus the raw counts. Thresholds (`FREQUENT_CUT_CHANGE_WINDOW_DAYS = 30`, `FREQUENT_CUT_CHANGE_MIN_COUNT = 3`) are exported so the UI copy stays in sync.
- `components/ExplorerChart/index.tsx` — new optional `titleTrailing?: React.ReactNode` slot rendered next to the chart title, *outside* the title's `ExplorerTooltip` so adornments have their own hover target.
- `components/OrchestratorCutHistory/index.tsx` — renders a `FrequentChangeIndicator` in that slot per chart. Reward and fee are computed independently so only the volatile cut gets flagged. Tooltip copy is informational ("worth reviewing before delegating"), not a judgement.

## Design notes

- Threshold is deliberately lenient (3-in-30-days); most honest orchestrators won't trip it.
- Matches the existing self-redeem pattern (amber `ExclamationTriangleIcon` + `ExplorerTooltip`) so it reads as the same class of signal.
- ROI math in `lib/roi.ts` still uses spot cut values — this PR does not try to incorporate history into projections. That's a bigger conversation; the warning icon is the smallest useful step.

## Test plan

- [ ] Typecheck, lint, prettier — all green locally (`pnpm typecheck`, `pnpm exec eslint --max-warnings 0`, `pnpm exec prettier --check`).
- [ ] Visit an orchestrator page with a cut history that oscillates inside 30 days → warning icon appears next to `Reward Cut` and/or `Fee Cut` title with the tooltip.
- [ ] Visit an orchestrator with a stable cut history → no warning on either chart.
- [ ] Confirm reward and fee warnings trigger independently (pick an O that only changed one of the two).
- [ ] Sanity-check the warning doesn't appear on orchestrators with no update events at all.

https://claude.ai/code/session_01H2PtgCW1vySoLnGWA38J73